### PR TITLE
Fix CountryField import location in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ corresponding to the official ISO 3166-1 list of countries (with a default
 Consider the following model using a ``CountryField``::
 
     from django.db import models
-    from django_countries import CountryField
+    from django_countries.fields import CountryField
 
     class Person(models.Model):
         name = models.CharField(max_length=100)


### PR DESCRIPTION
The old one no longer works in 2.0.
