### PR TITLE
CountryField: Prevent problem where reconstructing a field with South le...

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -95,8 +95,11 @@ class CountryField(CharField):
 
     def __init__(self, *args, **kwargs):
         self.countries_flag_url = kwargs.pop('countries_flag_url', None)
-        super(CharField, self).__init__(
-            max_length=2, choices=countries, *args, **kwargs)
+        kwargs.update({
+            'max_length': 2,
+            'choices': countries,
+        })
+        super(CharField, self).__init__(*args, **kwargs)
 
     def get_internal_type(self):
         return "CharField"


### PR DESCRIPTION
...ads to max_length being passed twice

I installed `django-countries==2.0b2` in an internal project of mine, changed the `CountryField` import and ran `./manage.py schemamigration contacts --auto` to see whether anything changed. The field reconstruction failed with a `TypeError` because South also put the `max_length` into the serialized model representation.

Instead of reverting a part of 5c9a6cf7409ada28fc00dc0fe0f41a21553d426c I choose to follow your implementation change, where `max_length` and `choices` are set unconditionally to their values.
