### PR TITLE
fix bug in django-countries which was conflicting with third party libraries 

### DIFF
--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -64,7 +64,7 @@ class Countries(object):
         this will solve bug related to generating fixtures
         django_dynamic_fixture
         """
-        return len(dict(sorted(self.countries, key=itemgetter(1))))
+        return len(self.countries)
 
 
 countries = Countries()


### PR DESCRIPTION
fix bug in django-countries which was conflicting with django_dynamic_fixture when loading fixtures, it was causing any len(fields.choices) operation to fail
