### PR TITLE
allow indexing and slicing of `Countries` object

### DIFF
--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -1,3 +1,4 @@
+from itertools import islice
 from operator import itemgetter
 
 from django_countries.conf import settings
@@ -60,11 +61,22 @@ class Countries(object):
         return dict(self.countries).get(code, '')
 
     def __len__(self):
-        """ len() used by several third party applications to calculate the length of choices
-        this will solve bug related to generating fixtures
+        """
+        len() used by several third party applications to calculate the length
+        of choices this will solve bug related to generating fixtures
         django_dynamic_fixture
         """
         return len(self.countries)
 
+    def __getitem__(self, index):
+        """
+        some applications expect to be able to access members of the field
+        choices by index
+        """
+        try:
+            return next(islice(self.__iter__(), index, index+1))
+        except TypeError:
+            return list(islice(self.__iter__(), index.start, index.stop,
+                               index.step))
 
 countries = Countries()

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -24,6 +24,19 @@ class TestCountriesObject(TestCase):
         with self.settings(COUNTRIES_OVERRIDE={'XX': 'Neverland'}):
             self.assertEqual(len(countries), self.EXPECTED_COUNTRY_COUNT + 1)
 
+    def test_countries_getitem(self):
+        try:
+            country = countries[0]
+        except TypeError as e:
+            self.fail(e.message)
+
+    def test_countries_slice(self):
+        try:
+            sliced = countries[10:20:2]
+        except TypeError as e:
+            self.fail(e.message)
+        self.assertEqual(len(sliced), 5)
+
     def test_countries_custom_ugettext_evaluation(self):
 
         class FakeLazyUGetText(object):


### PR DESCRIPTION
I had some code that did this on a model with a `CountryField`:
`setattr(user, field_name, field.choices[0][0])`

it used to work but in new version of django_countries the choices is a `Countries` object

this pull makes indexing and slicing work
