### PR TITLE
Don't include the country choices in migration operations.

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -136,6 +136,10 @@ class CountryField(CharField):
         value = super(CharField, self).pre_save(*args, **kwargs)
         return self.get_prep_value(value)
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(CountryField, self).deconstruct()
+        kwargs.pop('choices')
+        return name, path, args, kwargs
 
 # If south is installed, ensure that CountryField will be introspected just
 # like a normal CharField.


### PR DESCRIPTION
Just a simple one: when using the new makemigrations command, it sticks all of the
country choices into the migration file, which I think is unnecessary.

This patch removes those items from the migrations file.
