### PR TITLE
.gitignore updated: added *.pyc to the list of ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 iso3166-1.csv
 .tox/
 dist/
+*.pyc
+


### PR DESCRIPTION
I have added *.pyc files to the .gitignore. Could you please merge it with the main tree?
