### PR TITLE
removed unicode character

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ For example::
     ...     print("{name} ({code})".format(name=name, code=code))
     ...
     Afghanistan (AF)
-    Åland Islands (AX)
+    Aland Islands (AX)
     Albania (AL)
 
 Country names are translated using Django's standard ``ugettext``.


### PR DESCRIPTION
removed unicode character in order to fix pip install issue reported https://github.com/SmileyChris/django-countries/issues/75
