### PR TITLE
Add common name for Macedonia

### DIFF
--- a/django_countries/data.py
+++ b/django_countries/data.py
@@ -33,6 +33,7 @@ COMMON_NAMES = {
     "KR": _("South Korea"),
     "LA": _("Laos"),
     "MD": _("Moldovia"),
+    "MK": _("Macedonia"),
     "RU": _("Russia"),
     "SY": _("Syria"),
     "TW": _("Taiwan"),


### PR DESCRIPTION
In the spirit of some of the other common name overrides, this seems like a good addition. The current parenthetical part is not seen at all in http://en.wikipedia.org/wiki/Republic_of_Macedonia
