### PR TITLE
Attempt to allow null and empty country objects

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -17,16 +17,16 @@ from django_countries.conf import settings
 @python_2_unicode_compatible
 class Country(object):
     def __init__(self, code, flag_url=None):
-        if not code:
-            raise ValueError("Country code can not be blank")
         self.code = code
         self.flag_url = flag_url
 
     def __str__(self):
+        if not self.code:
+            return ''
         return force_text(self.code)
 
     def __eq__(self, other):
-        return force_text(self) == force_text(other)
+        return str(self) == str(other)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -111,7 +111,7 @@ class CountryDescriptor(object):
                 % (self.field.name, owner.__name__))
         code = instance.__dict__[self.field.name]
         if not code:
-            return code
+            return Country(code=code)
         return Country(
             code=code,
             flag_url=self.field.countries_flag_url,
@@ -174,6 +174,11 @@ class CountryField(CharField):
         "Returns field's value just before saving."
         value = super(CharField, self).pre_save(*args, **kwargs)
         return self.get_prep_value(value)
+
+    def get_prep_value(self, value):
+        if hasattr(value, 'code'):
+            value = value.code
+        return super(CountryField, self).get_prep_value(value)
 
     def deconstruct(self):
         """

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -113,12 +113,12 @@ class TestCountryField(TestCase):
     def test_save_empty_country(self):
         Person.objects.create(name='The Outsider')
         person = Person.objects.get()
-        self.assertEqual(person.country, '')
+        self.assertEqual(person.country, fields.Country(None))
 
     def test_save_null_country_allowed(self):
         AllowNull.objects.create(country=None)
         nulled = AllowNull.objects.get()
-        self.assertIsNone(nulled.country)
+        self.assertEqual(nulled.country, fields.Country(None))
 
     def test_save_null_country_not_allowed(self):
         self.assertRaises(
@@ -151,8 +151,9 @@ class TestCountryObject(TestCase):
             repr(country2),
             'Country(code={0}, flag_url={1})'.format(repr('XX'), repr('')))
 
-    def test_no_blank_code(self):
-        self.assertRaises(ValueError, fields.Country, code='', flag_url='')
+    def test_blank_code(self):
+        country = fields.Country(code=None)
+        self.assertEqual(country.code, None)
 
     def test_ioc_code(self):
         country = fields.Country(code='NL', flag_url='')


### PR DESCRIPTION
Possible fix for #82. I'm not totally certain I got everything right, as we might want to add more tests to verify behavior is working appropriately. The biggest thing to check here might be the round-tripping of both `None` and `u''` values, to make sure the code attribute is set appropriately on the returned Country object from the descriptor.
