### PR TITLE
Add CHANGES.rst to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include CHANGES.rst
 include LICENSE
 include tox.ini
 graft django_countries/static/flags


### PR DESCRIPTION
If I'm not mistaken, the absence of the changes file in the manifest is what's causing the failed setup :
```python
IOError: [Errno 2] No such file or directory: 'CHANGES.rst'
```
I guess a quick bugfix release is in order, since 3.1 is unusable.

Cheers.

And keep up the good work :+1: 