### PR TITLE
Remove escape function from widget, use format_html.

### DIFF
--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -1,5 +1,8 @@
+from __future__ import unicode_literals
+
 from django.forms import widgets
-from django.utils.html import escape
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from django.utils.functional import Promise
 
 from django_countries.conf import settings
@@ -11,7 +14,7 @@ COUNTRY_CHANGE_HANDLER = (
 )
 
 FLAG_IMAGE = (
-    '<img style="margin: 6px 4px; position: absolute;" src="{0}">')
+    '{0}<img style="margin: 6px 4px; position: absolute;" src="{1}">')
 
 
 class LazyChoicesMixin(object):
@@ -52,5 +55,4 @@ class CountrySelectWidget(LazySelect):
             country = value
         else:
             country = Country(value or '__')
-        data += FLAG_IMAGE.format(escape(country.flag))
-        return data
+        return format_html(FLAG_IMAGE, mark_safe(data), country.flag)


### PR DESCRIPTION
`format_html` is the safest way to do this.