### PR TITLE
fix XSS (reflected) in CountrySelectWidget

### DIFF
--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -5,9 +5,8 @@ except ImportError:
     import urlparse   # Python 2
 
 from django.forms import widgets
-from django.utils.html import escape
+from django.utils.html import format_html
 from django.utils.functional import Promise
-from django.utils.safestring import mark_safe
 
 from django_countries.conf import settings
 
@@ -40,6 +39,7 @@ class LazyChoicesMixin(object):
 
 
 class LazySelect(LazyChoicesMixin, widgets.Select):
+
     """
     A form Select widget that respects choices being a lazy object.
     """
@@ -51,7 +51,7 @@ class CountrySelectWidget(LazySelect):
         self.layout = kwargs.pop('layout', None) or (
             '{widget}<img class="country-select-flag" id="{flag_id}" '
             'style="margin: 6px 4px 0" '
-            'src="{country.flag}">'
+            'src="{flag}">'
         )
         super(CountrySelectWidget, self).__init__(*args, **kwargs)
 
@@ -71,5 +71,8 @@ class CountrySelectWidget(LazySelect):
             country = value
         else:
             country = Country(value or '__')
-        return mark_safe(self.layout.format(
-            widget=widget_render, country=country, flag_id=flag_id))
+
+        return format_html(self.layout,
+                           widget=widget_render,
+                           flag=country.flag,
+                           flag_id=flag_id)


### PR DESCRIPTION
fix XSS (reflected)
before if someone send  'FR\"><script>aler t(3)</script><' as country value, the script was executed.

This commit escape correctly the CountrySelectWidget 