### PR TITLE
Add “United Kingdom” as the common name

### DIFF
--- a/django_countries/data.py
+++ b/django_countries/data.py
@@ -28,6 +28,7 @@ except ImportError:  # pragma: no cover
 COMMON_NAMES = {
     "BN": _("Brunei"),
     "BO": _("Bolivia"),
+    "GB": _("United Kingdom"),
     "IR": _("Iran"),
     "KP": _("North Korea"),
     "KR": _("South Korea"),


### PR DESCRIPTION
The official name “United Kingdom of Great Britain and Northern Ireland” is just annoying, it's like referring to Rhode Island as “The State of Rhode Island and Providence Plantations”.

I'm British and travel a lot, and I've never heard anyone seriously refer to my country by its official name.

Also, this is the longest country name, so as things are, the unnecessary length could cause layout issues on some sites.
