### PR TITLE
Sort country list by localized name

### DIFF
--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -36,7 +36,8 @@ class LazyChoicesMixin(object):
         self._set_choices(value)
 
     def _set_choices(self, value):
-        self._choices = value
+        self._choices = sorted(list(value),
+                               key=lambda country: country[1])
 
 
 class LazySelect(LazyChoicesMixin, widgets.Select):


### PR DESCRIPTION
Hi,

Very nice package, saved me a lot of time preparing form.
However one thing missing is sorting fields by localized names instead of value.
I have created a form field in my own form instance in order to have values sorted but I feel
this should be done automatically and seamlessly based on used translation.
I was trying to figure out a place where this sorting can be done. LazyChoiceMixin is a place
where this can be done however I feel like it is not the best place to do it. It is a generic class
but on the other hand it is used in handling choices only.
What are your thoughts?

