### PR TITLE
Allow using unicode flag symbols.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,18 @@ An object used to represent a country, instanciated with a two character
 country code.
 
 It can be compared to other objects as if it was a string containing the
-country code and when evaluated as text, returns the country code.  
+country code and when evaluated as text, returns the country code.
 
 name
   Contains the full country name.
 
 flag
   Contains a URL to the flag.
+
+unicode_flag
+  A unicode glyph for the flag for this country. Currently well-supported in
+  iOS and OS X. See https://en.wikipedia.org/wiki/Regional_Indicator_Symbol
+  for details.
 
 alpha3
   The three letter country code for this country.
@@ -234,7 +239,7 @@ To customize an individual field, rather than rely on project level settings,
 create a ``Countries`` subclass which overrides settings.
 
 To override a setting, give the class an attribute matching the lowercased
-setting without the ``COUNTRIES_`` prefix. 
+setting without the ``COUNTRIES_`` prefix.
 
 Then just reference this class in a field. For example, this ``CountryField``
 uses a custom country list that only includes the G8 countries::

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -119,6 +119,7 @@ class Country(object):
 
         https://en.wikipedia.org/wiki/Regional_Indicator_Symbol
 
+        Currently, these glyphs appear to only be supported on OS X and iOS.
         """
         if not self.code:
             return ''

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -63,6 +63,11 @@ class TestCountryField(TestCase):
         self.assertEqual(
             person.other_country.flag, '//flags.example.com/us.gif')
 
+    def test_unicode_flags(self):
+        person = Person(name='Matthew Schinckel', country='AU', other_country='DE')
+        self.assertEqual(person.country.unicode_flag, u'🇦🇺')
+        self.assertEqual(person.other_country.unicode_flag, u'🇩🇪')
+
     def test_COUNTRIES_FLAG_URL_setting(self):
         # Custom relative url
         person = Person(name='Chris Beaven', country='NZ')


### PR DESCRIPTION
Here's something cool I worked on today. Now platforms have mostly full support for unicode flags, we can have them generated here, which means rendering will not require fetching an image.

(This is even nicer when you use it as a data-attribute on a select option, and have it update the display when the selection changes).