### PR TITLE
Django 1.9 fixes

### DIFF
--- a/django_countries/templatetags/countries.py
+++ b/django_countries/templatetags/countries.py
@@ -1,10 +1,11 @@
-from django import template
+from django import VERSION, template
 from django_countries.fields import Country
 
 
 register = template.Library()
 
+simple_tag = register.assignment_tag if VERSION < (1, 9) else register.simple_tag
 
-@register.assignment_tag
+@simple_tag
 def get_country(code):
     return Country(code=code)

--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -15,3 +15,11 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+    },
+]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ setenv =
 deps =
     {[base]deps}
     django18: Django<1.9
-    django19: Django==1.9beta1
+    django19: Django<1.10
 commands =
     {envbindir}/coverage run -a --source django_countries {envbindir}/django-admin.py test {posargs:django_countries.tests}
 


### PR DESCRIPTION
There's a remaining test failure in `django_countries.tests.test_fields.TestModelForm.test_translated_choices` but it's unrelated to these changes and already present on the master branch:

```
======================================================================
FAIL: test_translated_choices (django_countries.tests.test_fields.TestModelForm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "django_countries/tests/test_fields.py", line 255, in test_translated_choices
    form.fields['country'].widget.choices[1][1], 'Afganio')
AssertionError: u'Afghanistan' != u'Afganio'
- Afghanistan
+ Afganio
```

Thanks!