### PR TITLE
Add type check.

### DIFF
--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -70,6 +70,8 @@ class Countries(object):
                     self._countries.update(COMMON_NAMES)
                 override = self.get_option('override')
                 if override:
+                    if not isinstance(override, dict):
+                        raise TypeError('COUNTRIES_OVERRIDE must be a dictionary')
                     self._countries.update(override)
                     self._countries = dict(
                         (code, name) for code, name in self._countries.items()


### PR DESCRIPTION
This change prevents users from setting `COUNTRIES_OVERRIDE` to something like `{'AU', 'NZ'}`. Previously, if they had done that, `self._countries.update(override)` would have proceeded erroneously without raising an exception.