### PR TITLE
Added an option for alphanumeric sorting for COUNTRIES_FIRST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ target/
 ehthumbs.db
 Icon?
 Thumbs.db
+
+
+# PyCharm
+/.idea/

--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -130,8 +130,15 @@ class Countries(object):
         countries = self.countries
 
         # Yield countries that should be displayed first.
-        for code in self.countries_first:
-            yield (code, force_text(countries[code]))
+        countries_first = [
+            (code, force_text(countries[code])) for code in self.countries_first
+        ]
+
+        if self.get_option('first_sort'):
+            countries_first = sorted(countries_first, key=sort_key)
+
+        for item in countries_first:
+            yield item
 
         if self.countries_first:
             first_break = self.get_option('first_break')

--- a/django_countries/conf.py
+++ b/django_countries/conf.py
@@ -93,4 +93,11 @@ class Settings(AppSettings):
     countries.
     """
 
+    COUNTRIES_FIRST_SORT = False
+    """
+    Countries listed in :attr:`COUNTRIES_FIRST` will be alphanumerically
+    sorted based on their translated name instead of relying on their
+    order in :attr:`COUNTRIES_FIRST`.
+    """
+
 settings = Settings()

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -184,6 +184,24 @@ class CountriesFirstTest(BaseTest):
                            COUNTRIES_FIRST_BREAK='------'):
             self.assertEqual(len(countries), EXPECTED_COUNTRY_COUNT)
 
+    def test_sorted_countries_first_english(self):
+        with self.settings(COUNTRIES_FIRST=['YE', 'JO', 'DZ'], COUNTRIES_FIRST_SORT=True, LANGUAGE_CODE='en'):
+            countries_list = list(countries)
+            sorted_codes = [item[0] for item in countries_list[:3]]
+            self.assertEquals(['DZ', 'JO', 'YE'], sorted_codes)
+
+    def test_unsorted_countries_first_english(self):
+        with self.settings(COUNTRIES_FIRST=['YE', 'JO', 'DZ'], COUNTRIES_FIRST_SORT=False, LANGUAGE_CODE='en'):
+            countries_list = list(countries)
+            unsorted_codes = [item[0] for item in countries_list[:3]]
+            self.assertEquals(['YE', 'JO', 'DZ'], unsorted_codes)
+
+    def test_sorted_countries_first_arabic(self):
+        with self.settings(COUNTRIES_FIRST=['YE', 'JO', 'DZ'], COUNTRIES_FIRST_SORT=True, LANGUAGE_CODE='ar'):
+            countries_list = list(countries)
+            sorted_codes = [item[0] for item in countries_list[:3]]
+            self.assertEquals(['JO', 'DZ', 'YE'], sorted_codes)
+
 
 class TestCountriesCustom(BaseTest):
 


### PR DESCRIPTION
I needed this option on my English/Arabic edX platform site ([Edraak](https://edraak.org)).

The tests depends on `pyuca` to be working, but I couldn't manage to run anything besides `$ tex -e py27-django18` on my Mac.

So the tests are broken, but I *think* (it works for manual tests) that they're actually functional, and it needs only to have `pica`.

----

If you're an edX platform developer and want this feature check: https://github.com/Edraak/edx-platform/pull/201 for an example how to integrate it.