### PR TITLE
fixed migrations when multiple=True

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -282,6 +282,8 @@ class CountryField(CharField):
         """
         name, path, args, kwargs = super(CountryField, self).deconstruct()
         kwargs.pop('choices')
+        if self.multiple:      # multiple determines the length of the field
+            kwargs['multiple'] = self.multiple
         if self.countries is not countries:
             # Include the countries class if it's not the default countries
             # instance.


### PR DESCRIPTION
When generating migrations with multiple=True set on the field, the length of the field is incorrect (2 instead of 599) and the multiple kwarg is not included in the generated migration.

This fixes both.

I haven't written tests for migrations and don't have time to dig into it right now, but if you point me in the right direction I can give it a try later and add it to this request.

Thanks for the great library :)