### PR TITLE
Replace 'UK' with 'GB' in `COUNTRIES_ONLY` example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,7 +204,7 @@ or to specify your own country names, use a dictionary or two-tuple list
 
     COUNTRIES_ONLY = [
         'US',
-        'UK'
+        'GB',
         ('NZ', _('Middle Earth')),
         ('AU', _('Desert')),
     ]


### PR DESCRIPTION
Because there is no 'UK', only 'GB', so copying that example generates a `KeyError: 'UK'`.
Also add a missing comma after it.