### PR TITLE
Fix for single field customisation Country object

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -49,11 +49,15 @@ class TemporaryEscape(object):
 @python_2_unicode_compatible
 class Country(object):
 
-    def __init__(self, code, flag_url=None, str_attr='code'):
+    def __init__(self, code, flag_url=None, str_attr='code',countries_object=None):
         self.code = code
         self.flag_url = flag_url
         self._escape = False
         self._str_attr = str_attr
+        if countries_object is not None and isinstance(countries_object, countries.__class__):
+            self.countries = countries_object 
+        else:
+            self.countries = countries
 
     def __str__(self):
         return force_text(getattr(self, self._str_attr) or '')
@@ -95,19 +99,19 @@ class Country(object):
 
     @property
     def name(self):
-        return self.maybe_escape(countries.name(self.code))
+        return self.maybe_escape(self.countries.name(self.code))
 
     @property
     def alpha3(self):
-        return countries.alpha3(self.code)
+        return self.countries.alpha3(self.code)
 
     @property
     def numeric(self):
-        return countries.numeric(self.code)
+        return self.countries.numeric(self.code)
 
     @property
     def numeric_padded(self):
-        return countries.numeric(self.code, padded=True)
+        return self.countries.numeric(self.code, padded=True)
 
     @property
     def flag(self):
@@ -157,12 +161,11 @@ class Country(object):
         code = ioc_data.IOC_TO_ISO.get(ioc_code, '')
         if code == '':
             return None
-        return Country(code, flag_url=flag_url)
+        return Country(code, flag_url=flag_url, countries_object=self.countries)
 
     @property
     def ioc_code(self):
         return ioc_data.ISO_TO_IOC.get(self.code, '')
-
 
 class CountryDescriptor(object):
     """
@@ -195,7 +198,7 @@ class CountryDescriptor(object):
         return self.country(value)
 
     def country(self, code):
-        return Country(code=code, flag_url=self.field.countries_flag_url)
+        return Country(code=code, flag_url=self.field.countries_flag_url, countries_object=self.field.countries)
 
     def __set__(self, instance, value):
         if self.field.multiple:


### PR DESCRIPTION
When using Single field customization the field.Country object has
no knowledge of your custom Countries object. Therefor it returns
always the properties of the default countries object.
This commit fixes that by passing the countries object from the
CountryField in CountryDescriptor to Country

Example (following G8Countries example):
```
 # Old situation
 >>> myvote = Vote(country='EU')
 >>> print(myvote.country.name)
 '' (empty string)
 # New situation
 >>> print(myvote.country.name)
 'European Union'
```