### PR TITLE
Do not try to import south - it's unsuported

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -309,12 +309,3 @@ class CountryField(CharField):
                 if self.multiple else LazyTypedChoiceField)
         field = super(CharField, self).formfield(**kwargs)
         return field
-
-
-# If south is installed, ensure that CountryField will be introspected just
-# like a normal CharField.
-try:  # pragma: no cover
-    from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ['^django_countries\.fields\.CountryField'])
-except ImportError:
-    pass


### PR DESCRIPTION
Because django-countries supports only Django 1.8+ and South is not compatible with these Django versions then we need to remove the south introspection rules.

This will also prevent some errors when upgrade from older versions of Django (pre 1.7) to new Django versions (1.9+) and South is still left in the environment.