### PR TITLE
Add support for countries as choices in DRF serializer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -326,7 +326,36 @@ the REST interface. For example::
 
 
 You can optionally instantiate the field with ``countries`` with a custom
-Countries_ instance.
+Countries_ instance. When you request OPTIONS against this resource (using
+the DRF `metadata support <http://www.django-rest-framework.org/api-guide/metadata/>`_) the countries will be returned in the response as choices:
+
+.. code:: text
+
+    OPTIONS /api/address/ HTTP/1.1
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+    Allow: GET, POST, HEAD, OPTIONS
+
+    {
+    "actions": {
+      "POST": {
+        "country": {
+        "type": "choice",
+        "label": "Country",
+        "choices": [
+          {
+            "display_name": "Australia",
+            "value": "AU"
+          },
+          [...]
+          {
+            "display_name": "United Kingdom",
+            "value": "GB"
+          }
+        ]
+      }
+    }
 
 .. _Countries: `Single field customization`_
 

--- a/django_countries/serializer_fields.py
+++ b/django_countries/serializer_fields.py
@@ -6,13 +6,13 @@ from django.utils.encoding import force_text
 from django_countries import countries
 
 
-class CountryField(serializers.Field):
+class CountryField(serializers.ChoiceField):
 
     def __init__(self, *args, **kwargs):
         self.country_dict = kwargs.pop('country_dict', None)
         countries_class = kwargs.pop('countries', None)
         self.countries = countries_class() if countries_class else countries
-        super(CountryField, self).__init__(*args, **kwargs)
+        super(CountryField, self).__init__(self.countries, *args, **kwargs)
 
     def to_representation(self, obj):
         code = self.countries.alpha2(obj)

--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -16,6 +16,7 @@ STATIC_URL = '/static-assets/'
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.locale.LocaleMiddleware'
 )
 
 TEMPLATES = [

--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -1,6 +1,8 @@
 SECRET_KEY = 'test'
 
 INSTALLED_APPS = (
+    'django.contrib.contenttypes',
+    'django.contrib.auth',
     'django_countries',
     'django_countries.tests',
 )

--- a/django_countries/tests/test_drf.py
+++ b/django_countries/tests/test_drf.py
@@ -1,19 +1,30 @@
 from __future__ import unicode_literals
 
 from django.test import TestCase
-from rest_framework import serializers
 
+from django_countries import countries
 from django_countries.tests.models import Person
+from django_countries.tests.custom_countries import FantasyCountries
 from django_countries.serializer_fields import CountryField
+
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+from rest_framework import serializers, views
+
+
+def countries_display(countries):
+    """Convert Countries into a DRF-OPTIONS formatted dict."""
+    return [{'display_name': v, 'value': k} for (k, v) in countries]
 
 
 class PersonSerializer(serializers.ModelSerializer):
     country = CountryField()
     other_country = CountryField(country_dict=True, required=False)
+    favourite_country = CountryField(countries=FantasyCountries)
 
     class Meta:
         model = Person
-        fields = ('name', 'country', 'other_country')
+        fields = ('name', 'country', 'other_country', 'favourite_country')
 
 
 class TestDRF(TestCase):
@@ -23,7 +34,12 @@ class TestDRF(TestCase):
         serializer = PersonSerializer(person)
         self.assertEqual(
             serializer.data,
-            {'name': 'Chris Beaven', 'country': 'NZ', 'other_country': ''})
+            {
+                'name': 'Chris Beaven',
+                'country': 'NZ',
+                'other_country': '',
+                'favourite_country': 'NZ'
+            })
 
     def test_serialize_country_dict(self):
         person = Person(name='Chris Beaven', other_country='AU')
@@ -34,15 +50,47 @@ class TestDRF(TestCase):
                 'name': 'Chris Beaven',
                 'country': '',
                 'other_country': {'code': 'AU', 'name': 'Australia'},
+                'favourite_country': 'NZ'
             })
 
     def test_deserialize(self):
-        serializer = PersonSerializer(data={'name': 'Tester', 'country': 'US'})
+        serializer = PersonSerializer(data={
+            'name': 'Tester',
+            'country': 'US',
+            'favourite_country': 'NV'
+        })
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.validated_data['country'], 'US')
 
     def test_deserialize_country_dict(self):
         serializer = PersonSerializer(data={
-            'name': 'Tester', 'country': {'code': 'GB', 'name': 'Anything'}})
+            'name': 'Tester',
+            'country': {'code': 'GB', 'name': 'Anything'},
+            'favourite_country': 'NV'
+        })
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.validated_data['country'], 'GB')
+
+
+class TestDRFMetadata(TestCase):
+
+    """Tests against the DRF OPTIONS API metadata endpoint."""
+
+    def test_actions(self):
+
+        class ExampleView(views.APIView):
+            """Example view."""
+            def post(self, request):
+                pass
+
+            def get_serializer(self):
+                return PersonSerializer()
+
+        request = Request(APIRequestFactory().options('/'))
+        view = ExampleView.as_view()
+        response = view(request=request)
+        country_choices = response.data['actions']['POST']['country']['choices']
+        favourite_choices = response.data['actions']['POST']['favourite_country']['choices']
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(country_choices, countries_display(countries))
+        self.assertEqual(favourite_choices, countries_display(FantasyCountries()))

--- a/django_countries/tests/test_drf.py
+++ b/django_countries/tests/test_drf.py
@@ -82,9 +82,6 @@ class TestDRFMetadata(TestCase):
             def post(self, request):
                 pass
 
-            def get(self, request):
-                return HttpResponse(request.META['HTTP_ACCEPT_LANGUAGE'])
-
             def get_serializer(self):
                 return PersonSerializer()
 


### PR DESCRIPTION
Note: this is a duplicate to PR #172 - but I'd already written it by the time I saw that - sorry.

Includes tests for the choices returned via the DRF API, and update to the docs.

---

Switching the CountryField field serializer to subclass ChoiceField
rather than a plain Field adds support for the choices argument,
which in turn means that the OPTIONS request will return all of
the supported countries. This is useful for JS applications where
the metadata API is used to pre-populate / validate input values.