### PR TITLE
Add test for model with property

### DIFF
--- a/django_countries/tests/models.py
+++ b/django_countries/tests/models.py
@@ -23,3 +23,16 @@ class AllowNull(models.Model):
 class MultiCountry(models.Model):
     countries = CountryField(multiple=True)
     uneditable_countries = CountryField(multiple=True, editable=False)
+
+
+class WithProp(models.Model):
+    country = CountryField()
+    _private_field = models.CharField(max_length=10)
+
+    @property
+    def public_field(self):
+        return self._private_field
+
+    @public_field.setter
+    def public_field(self, value):
+        self._private_field = value

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -9,7 +9,7 @@ from django.utils.encoding import force_text
 
 from django_countries import fields, countries
 from django_countries.tests import forms, custom_countries
-from django_countries.tests.models import Person, AllowNull, MultiCountry
+from django_countries.tests.models import Person, AllowNull, MultiCountry, WithProp
 
 
 class TestCountryField(TestCase):
@@ -154,6 +154,12 @@ class TestCountryField(TestCase):
     def test_render_form(self):
         Form = modelform_factory(Person, fields=['country'])
         Form().as_p()
+
+    def test_model_with_prop(self):
+        with_prop = WithProp(country='FR', public_field='test')
+
+        self.assertEqual(with_prop.country.code, 'FR')
+        self.assertEqual(with_prop.public_field, 'test')
 
 
 class TestValidation(TestCase):


### PR DESCRIPTION
The new test verifies that it is possible to instantiate a model
with a country field and a property field.

Currently, the test fails with django 1.11, and passes with other
versions.