### PR TITLE
Fix for #197

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -331,7 +331,7 @@ class CountryField(CharField):
                 blank_choice = BLANK_CHOICE_DASH
             else:
                 blank_choice = [('', self.blank_label)]
-        if self.multiple:
+        if self.multiple and not self.blank:
             include_blank = False
         return super(CountryField, self).get_choices(
             include_blank=include_blank, blank_choice=blank_choice, *args,


### PR DESCRIPTION
I believe this should address #197 without affecting the changes made for #191.  Basically we're just allowing for the field to be defined in the model with `blank=True` and have that definition carry through to the formfield.