### PR TITLE
Add import of `_` to COUNTRIES_OVERRIDE example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,6 +222,8 @@ Note that you will need to handle translation of customised country names.
 Setting a country's name to ``None`` will exclude it from the country list.
 For example::
 
+    from django.utils.translation import ugettext_lazy as _
+
     COUNTRIES_OVERRIDE = {
         'NZ': _('Middle Earth'),
         'AU': None


### PR DESCRIPTION
Alternative suggestion for #202 

Going into a full explanation of translatable strings here is a bit "heavyweight", I think... by just adding the import line to the example, people who already know what the line does (and have it in place already) can ignore it, and people who want to know more can google that line of code.