### PR TITLE
Update tests to cover djangorestframework 3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py36-django111-drf33
     py27-django18-drf33-pyuca
     py27-django18-drf{34,35,36}
+    py27-django110-drf37
     readme
     coverage_report
 skip_missing_interpreters = True
@@ -30,6 +31,7 @@ deps =
     drf34: djangorestframework>=3.4,<3.5
     drf35: djangorestframework>=3.5,<3.6
     drf36: djangorestframework>=3.6,<3.7
+    drf37: djangorestframework>=3.7,<3.8
     pyuca: pyuca
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
DRF 3.7 requires Django 1.10+, see https://github.com/encode/django-rest-framework/blob/3.7.0/docs/topics/3.7-announcement.md#django-20-support