### PR TITLE
Fix documentation of get_countries template tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ If you need a list of countries, there's also a simple tag for that:
     {% get_countries as countries %}
     <select>
     {% for country in countries %}
-        <option>{{ country.name }}</option>
+        <option value="{{ country.0 }}">{{ country.1 }}</option>
     {% endfor %}
     </select>
 


### PR DESCRIPTION
The `get_countries` template tag returns a list of 2-tuples. These tuples are unnamed so they can only accessed by index:

    >>> from django_countries.templatetags.countries import get_countries
    >>> c = get_countries()
    >>> type(c)
    <class 'list'>
    >>> len(c)
    249
    >>> type(c[156])
    <class 'tuple'>
    >>> len(c[156])
    2
    >>> c[156]
    ('NZ', 'New Zealand')
    >>> c[156][0]
    'NZ'
    >>> c[156][1]
    'New Zealand'
    >>> c[156].name
    Traceback (most recent call last):
      File "/usr/lib/python3.5/code.py", line 91, in runcode
        exec(code, self.locals)
      File "<console>", line 1, in <module>
    AttributeError: 'tuple' object has no attribute 'name'

My preference would be to change the `get_countries` tag to return a list of objects that provide the `.name` and `.code` attributes, but that would be backward incompatible and is probably not worth the trouble.

--
Python 3.5.2
Django 2.0.3
django-countries 5.2
