### PR TITLE
Less warnings when running with Django 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ release, and any new translations added.
 
 - Add bandit to the test suite for basic security analysis.
 
+- Avoid deprecation warnings when using django-countries with Django 3.0.
+
 
 5.5 (11 September 2019)
 =======================

--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ For example:
     Åland Islands (AX)
     Albania (AL)
 
-Country names are translated using Django's standard ``ugettext``.
+Country names are translated using Django's standard ``gettext``.
 If you would like to help by adding a translation, please visit
 https://www.transifex.com/projects/p/django-countries/
 
@@ -281,7 +281,7 @@ For example:
 
 .. code:: python
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     COUNTRIES_OVERRIDE = {
         'NZ': _('Middle Earth'),

--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 import six
 from django_countries.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import override
 
 from .base import CountriesBase
@@ -184,18 +184,18 @@ class Countries(CountriesBase):
             # Check if there's an older translation available if there's no
             # translation for the newest name.
             with override(None):
-                source_name = force_text(name)
-            name = force_text(name)
+                source_name = force_str(name)
+            name = force_str(name)
             if name == source_name:
                 for old_name in self.OLD_NAMES[code]:
                     with override(None):
-                        source_old_name = force_text(old_name)
-                    old_name = force_text(old_name)
+                        source_old_name = force_str(old_name)
+                    old_name = force_str(old_name)
                     if old_name != source_old_name:
                         name = old_name
                         break
         else:
-            name = force_text(name)
+            name = force_str(name)
         return CountryTuple(code, name)
 
     def __iter__(self):
@@ -230,7 +230,7 @@ class Countries(CountriesBase):
         if self.countries_first:
             first_break = self.get_option("first_break")
             if first_break:
-                yield ("", force_text(first_break))
+                yield ("", force_str(first_break))
 
         # Force translation before sorting.
         ignore_first = None if self.get_option("first_repeat") else self.countries_first
@@ -251,7 +251,7 @@ class Countries(CountriesBase):
 
         If no match is found, returns an empty string.
         """
-        code = force_text(code).upper()
+        code = force_str(code).upper()
         if code.isdigit():
             lookup_code = int(code)
 

--- a/django_countries/base.py
+++ b/django_countries/base.py
@@ -1,5 +1,5 @@
 try:
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 except ImportError:  # pragma: no cover
     # Allows this module to be executed without Django installed.
     def _(x):

--- a/django_countries/data.py
+++ b/django_countries/data.py
@@ -22,7 +22,7 @@ import os
 from django_countries.base import CountriesBase
 
 try:
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 except ImportError:  # pragma: no cover
     # Allows this module to be executed without Django installed.
     def _(x):

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -6,7 +6,7 @@ from django import forms
 from django.contrib.admin.filters import FieldListFilter
 from django.core import checks, exceptions
 from django.db.models.fields import BLANK_CHOICE_DASH, CharField
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import lazy
 from django.utils.html import escape as escape_html
 
@@ -33,7 +33,7 @@ def country_to_text(value):
         value = value.code
     if value is None:
         return None
-    return force_text(value)
+    return force_str(value)
 
 
 class TemporaryEscape(object):
@@ -70,16 +70,16 @@ class Country(object):
         self.code = self.countries.alpha2(code) or code
 
     def __str__(self):
-        return force_text(getattr(self, self._str_attr) or "")
+        return force_str(getattr(self, self._str_attr) or "")
 
     def __eq__(self, other):
-        return force_text(self.code or "") == force_text(other or "")
+        return force_str(self.code or "") == force_str(other or "")
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash(force_text(self))
+        return hash(force_str(self))
 
     def __repr__(self):
         args = ["code={country.code!r}"]
@@ -96,7 +96,7 @@ class Country(object):
     __nonzero__ = __bool__  # Python 2 compatibility.
 
     def __len__(self):
-        return len(force_text(self))
+        return len(force_str(self))
 
     @property
     def countries(self):

--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
 
 
@@ -23,7 +23,7 @@ class CountryFilter(admin.FieldListFilter):
         }
         for lookup, title in self.lookup_choices(changelist):
             yield {
-                "selected": value == force_text(lookup),
+                "selected": value == force_str(lookup),
                 "query_string": changelist.get_query_string(
                     {self.field.name: lookup}, []
                 ),

--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class CountryFilter(admin.FieldListFilter):

--- a/django_countries/serializer_fields.py
+++ b/django_countries/serializer_fields.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from rest_framework import serializers
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from django_countries import countries
 
@@ -19,7 +19,7 @@ class CountryField(serializers.ChoiceField):
             return ""
         if not self.country_dict:
             return code
-        return {"code": code, "name": force_text(self.countries.name(obj))}
+        return {"code": code, "name": force_str(self.countries.name(obj))}
 
     def to_internal_value(self, data):
         if not self.allow_blank and data == '':
@@ -29,7 +29,7 @@ class CountryField(serializers.ChoiceField):
             data = data.get("code")
         country = self.countries.alpha2(data)
         if data and not country:
-            country = self.countries.by_name(force_text(data))
+            country = self.countries.by_name(force_str(data))
             if not country:
                 self.fail("invalid_choice", input=data)
         return country

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -66,10 +66,10 @@ class TestCountriesObject(BaseTest):
         sliced = countries[10:20:2]
         self.assertEqual(len(sliced), 5)
 
-    def test_countries_custom_ugettext_evaluation(self):
+    def test_countries_custom_gettext_evaluation(self):
         class FakeLazyUGetText(object):
             def __bool__(self):  # pragma: no cover
-                raise ValueError("Can't evaluate lazy_ugettext yet")
+                raise ValueError("Can't evaluate lazy_gettext yet")
 
             __nonzero__ = __bool__
 

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -10,7 +10,7 @@ from django.forms import Select
 from django.forms.models import modelform_factory
 from django.test import TestCase, override_settings
 from django.utils import translation
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from django_countries import fields, countries, data
 from django_countries.fields import CountryField
@@ -46,7 +46,7 @@ class TestCountryField(TestCase):
 
     def test_text(self):
         person = Person(name="Chris Beaven", country="NZ")
-        self.assertEqual(force_text(person.country), "NZ")
+        self.assertEqual(force_str(person.country), "NZ")
 
     def test_name(self):
         person = Person(name="Chris Beaven", country="NZ")

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,4 +85,3 @@ ignore-bad-ideas = *.mo
 DJANGO_SETTINGS_MODULE = django_countries.tests.settings
 filterwarnings =
     module
-    ignore:force_text|smart_text|django.utils.translation.ugettext_lazy:PendingDeprecationWarning


### PR DESCRIPTION
```
commit 16ca30cf43e7a8c69a439e0ba1f453313e90ca92 (HEAD -> master, origin/mk/dj30-deprecations)
Author: Matthias Kestenholz <mk@feinheit.ch>
Date:   Tue Oct 15 10:00:25 2019 +0200

    Mention the deprecation-related changes in the changelog and drop the now unused ignore configuration

commit c0a5184febf9a3f1f7fbed53a233869dbc6dc68c
Author: Matthias Kestenholz <mk@feinheit.ch>
Date:   Tue Oct 15 09:58:08 2019 +0200

    Use force_str instead of force_text
    
    It has been introduced over 7 years ago[1] and has been the preferred
    name for several years now.
    
    [1]: https://github.com/django/django/commit/a120fac65a17137bc8ac710477478

commit 0f4258fe531e5c11ddd8929f0a4eb162dd2fc57b
Author: Matthias Kestenholz <mk@feinheit.ch>
Date:   Tue Oct 15 09:56:44 2019 +0200

    Start using gettext* instead of ugettext*
    
    The former has been available for a long time already.

```