### PR TITLE
Cleanup CI steps by removing deprecated version of python/django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 sudo: false
-dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/django_countries/templatetags/countries.py
+++ b/django_countries/templatetags/countries.py
@@ -4,12 +4,7 @@ from django_countries.fields import Country, countries
 
 
 register = template.Library()
-
-if django.VERSION < (1, 9):
-    # Support older versions without implicit assignment support in simple_tag.
-    simple_tag = register.assignment_tag
-else:
-    simple_tag = register.simple_tag
+simple_tag = register.simple_tag
 
 
 @simple_tag

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,10 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Framework :: Django
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,14 @@ distribute = False
 envlist =
     coverage_setup
     # Pyuca
-    py36-django22-drf39-pyuca
+    py37-django22-drf39-pyuca
     py27-django111-drf33-pyuca
     # Latest
     py37-django22-drf39
     # Historical
-    py36-django{111,20,21}-drf{37,38,39}
+    py36-django{111,20,21,22}-drf{37,38,39}
+    py37-django{20,21,22}-drf{37,38,39}
     py27-django111-drf{37,38,39}
-    py27-django18-drf{33,34,35,36}
     readme
     bandit
     coverage_report
@@ -18,11 +18,10 @@ skip_missing_interpreters = True
 
 [travis]
 python =
-    2.7: py27, readme, codecov
-    3.4: py34, codecov
+    2.7: py27, codecov
     3.5: py35, codecov
     3.6: py36, codecov
-    3.7: py37, bandit, codecov
+    3.7: py37, readme, bandit, codecov
 
 
 [testenv]
@@ -39,7 +38,6 @@ deps =
     drf38: djangorestframework==3.8.*
     drf39: djangorestframework==3.9.*
     pyuca: pyuca
-    django18: Django==1.8.*
     django111: Django==1.11.*
     django20: Django==2.0.*
     django21: Django==2.1.*
@@ -49,7 +47,7 @@ commands = pytest --cov --cov-append --cov-report=
 
 [testenv:readme]
 skip_install = True
-basepython = python2.7
+basepython = python3
 deps =
     docutils
     Pygments


### PR DESCRIPTION
Python 3.4 and Django 1.8 are deprecated