### PR TITLE
Add check if `max_length` is not explicitly defined to fix migrations

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -283,10 +283,11 @@ class CountryField(CharField):
         self.blank_label = kwargs.pop("blank_label", None)
         self.multiple = kwargs.pop("multiple", None)
         kwargs["choices"] = self.countries
-        if self.multiple:
-            kwargs["max_length"] = len(self.countries) * 3 - 1
-        else:
-            kwargs["max_length"] = 2
+        if "max_length" not in kwargs:
+            if self.multiple:
+                kwargs["max_length"] = len(self.countries) * 3 - 1
+            else:
+                kwargs["max_length"] = 2
         super(CharField, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):


### PR DESCRIPTION
This is essentially required for the migrations to identify changes in the multiple `CountryField` fields when new countries were added to the available countries dictionary.

Currently, any explicit definition of `max_length` on the field is ignored in `CountryField` constructor. This means that in the previous migration state the field length will always be the same as in the new state. We need to allow overriding `max_length` property for the `CountryField`.