### PR TITLE
Deprecate Python 2 and Django 1.x, add Django 3.0, DRF 3.10/11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 dist: xenial
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 install: pip install tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -230,7 +230,7 @@ For example:
     Åland Islands (AX)
     Albania (AL)
 
-Country names are translated using Django's standard ``ugettext``.
+Country names are translated using Django's standard ``gettext``.
 If you would like to help by adding a translation, please visit
 https://www.transifex.com/projects/p/django-countries/
 
@@ -281,7 +281,7 @@ For example:
 
 .. code:: python
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 
     COUNTRIES_OVERRIDE = {
         'NZ': _('Middle Earth'),

--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
-from __future__ import unicode_literals
 import itertools
 from collections import namedtuple
 
-import six
 from django_countries.conf import settings
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import override
 
 from .base import CountriesBase
@@ -77,7 +75,7 @@ class Countries(CountriesBase):
                 only_choices = True
                 if not isinstance(only, dict):
                     for item in only:
-                        if isinstance(item, six.string_types):
+                        if isinstance(item, str):
                             only_choices = False
                             break
             if only and only_choices:
@@ -101,7 +99,7 @@ class Countries(CountriesBase):
             if only and not only_choices:
                 countries = {}
                 for item in only:
-                    if isinstance(item, six.string_types):
+                    if isinstance(item, str):
                         countries[item] = self._countries[item]
                     else:
                         key, value = item
@@ -184,18 +182,18 @@ class Countries(CountriesBase):
             # Check if there's an older translation available if there's no
             # translation for the newest name.
             with override(None):
-                source_name = force_text(name)
-            name = force_text(name)
+                source_name = force_str(name)
+            name = force_str(name)
             if name == source_name:
                 for old_name in self.OLD_NAMES[code]:
                     with override(None):
-                        source_old_name = force_text(old_name)
-                    old_name = force_text(old_name)
+                        source_old_name = force_str(old_name)
+                    old_name = force_str(old_name)
                     if old_name != source_old_name:
                         name = old_name
                         break
         else:
-            name = force_text(name)
+            name = force_str(name)
         return CountryTuple(code, name)
 
     def __iter__(self):
@@ -230,7 +228,7 @@ class Countries(CountriesBase):
         if self.countries_first:
             first_break = self.get_option("first_break")
             if first_break:
-                yield ("", force_text(first_break))
+                yield ("", force_str(first_break))
 
         # Force translation before sorting.
         ignore_first = None if self.get_option("first_repeat") else self.countries_first
@@ -251,7 +249,7 @@ class Countries(CountriesBase):
 
         If no match is found, returns an empty string.
         """
-        code = force_text(code).upper()
+        code = force_str(code).upper()
         if code.isdigit():
             lookup_code = int(code)
 

--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -355,8 +355,6 @@ class Countries(CountriesBase):
     def __bool__(self):
         return bool(self.countries)
 
-    __nonzero__ = __bool__
-
     def __contains__(self, code):
         """
         Check to see if the countries contains the given code.

--- a/django_countries/base.py
+++ b/django_countries/base.py
@@ -1,5 +1,5 @@
 try:
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 except ImportError:  # pragma: no cover
     # Allows this module to be executed without Django installed.
     def _(x):

--- a/django_countries/base.py
+++ b/django_countries/base.py
@@ -6,7 +6,7 @@ except ImportError:  # pragma: no cover
         return x
 
 
-class CountriesBase(object):
+class CountriesBase:
     COMMON_NAMES = {
         "BN": _("Brunei"),
         "BO": _("Bolivia"),

--- a/django_countries/conf.py
+++ b/django_countries/conf.py
@@ -13,7 +13,7 @@ class AppSettings(object):
                 return getattr(django.conf.settings, attr)
             except AttributeError:
                 pass
-        return super(AppSettings, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
 
 class Settings(AppSettings):

--- a/django_countries/conf.py
+++ b/django_countries/conf.py
@@ -1,7 +1,7 @@
 import django.conf
 
 
-class AppSettings(object):
+class AppSettings:
     """
     A holder for app-specific default settings that allows overriding via
     the project's settings.

--- a/django_countries/data.py
+++ b/django_countries/data.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 This is a self-generating script that contains all of the iso3166-1 data.
 
@@ -15,7 +14,6 @@ how to do that:
 7. Save as a CSV file in django_countries/iso3166-1.csv
 8. Run this script from the command line
 """
-from __future__ import unicode_literals
 import glob
 import os
 

--- a/django_countries/data.py
+++ b/django_countries/data.py
@@ -20,7 +20,7 @@ import os
 from django_countries.base import CountriesBase
 
 try:
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
 except ImportError:  # pragma: no cover
     # Allows this module to be executed without Django installed.
     def _(x):

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -276,7 +276,7 @@ class CountryField(CharField):
             kwargs["max_length"] = len(self.countries) * 3 - 1
         else:
             kwargs["max_length"] = 2
-        super().__init__(*args, **kwargs)
+        super(CharField, self).__init__(*args, **kwargs)
 
     def check(self, **kwargs):
         errors = super().check(**kwargs)
@@ -310,7 +310,7 @@ class CountryField(CharField):
 
     def pre_save(self, *args, **kwargs):
         "Returns field's value just before saving."
-        value = super().pre_save(*args, **kwargs)
+        value = super(CharField, self).pre_save(*args, **kwargs)
         return self.get_prep_value(value)
 
     def get_prep_value(self, value):
@@ -321,7 +321,7 @@ class CountryField(CharField):
                 value = ",".join(value)
             else:
                 value = ""
-        return super().get_prep_value(value)
+        return super(CharField, self).get_prep_value(value)
 
     def get_clean_value(self, value):
         if value is None:

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -82,8 +82,6 @@ class Country:
     def __bool__(self):
         return bool(self.code)
 
-    __nonzero__ = __bool__  # Python 2 compatibility.
-
     def __len__(self):
         return len(force_str(self))
 
@@ -164,15 +162,7 @@ class Country:
         # codes we can get the flag.
         OFFSET = 127397
         points = [ord(x) + OFFSET for x in self.code.upper()]
-
-        try:
-            # Python 3 is simple: we can just chr() the unicode points.
-            return chr(points[0]) + chr(points[1])
-        except ValueError:
-            # Python 2 requires us to be a bit more creative. We could use
-            # unichr(), but that only works if the python has been compiled
-            # with wide unicode support. This method should always work.
-            return ("\\U%08x\\U%08x" % tuple(points)).decode("unicode-escape")
+        return chr(points[0]) + chr(points[1])
 
     @staticmethod
     def country_from_ioc(ioc_code, flag_url=""):

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -1,26 +1,16 @@
-from __future__ import unicode_literals
-
 import pkg_resources
-import six
+from urllib import parse as urlparse
+
 from django import forms
 from django.contrib.admin.filters import FieldListFilter
 from django.core import checks, exceptions
 from django.db.models.fields import BLANK_CHOICE_DASH, CharField
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import lazy
 from django.utils.html import escape as escape_html
 
 from django_countries import countries, filters, ioc_data, widgets
 from django_countries.conf import settings
-
-try:
-    from urllib import parse as urlparse
-except ImportError:
-    import urlparse  # Python 2
-try:
-    basestring
-except NameError:
-    basestring = str  # Python 3
 
 EXTENSIONS = dict(
     (ep.name, ep.load())
@@ -33,7 +23,7 @@ def country_to_text(value):
         value = value.code
     if value is None:
         return None
-    return force_text(value)
+    return force_str(value)
 
 
 class TemporaryEscape(object):
@@ -55,7 +45,6 @@ class TemporaryEscape(object):
         self.country._escape = self.original_escape
 
 
-@six.python_2_unicode_compatible
 class Country(object):
     def __init__(self, code, flag_url=None, str_attr="code", custom_countries=None):
         self.flag_url = flag_url
@@ -70,16 +59,16 @@ class Country(object):
         self.code = self.countries.alpha2(code) or code
 
     def __str__(self):
-        return force_text(getattr(self, self._str_attr) or "")
+        return force_str(getattr(self, self._str_attr) or "")
 
     def __eq__(self, other):
-        return force_text(self.code or "") == force_text(other or "")
+        return force_str(self.code or "") == force_str(other or "")
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash(force_text(self))
+        return hash(force_str(self))
 
     def __repr__(self):
         args = ["code={country.code!r}"]
@@ -96,7 +85,7 @@ class Country(object):
     __nonzero__ = __bool__  # Python 2 compatibility.
 
     def __len__(self):
-        return len(force_text(self))
+        return len(force_str(self))
 
     @property
     def countries(self):
@@ -339,8 +328,8 @@ class CountryField(CharField):
             return None
         if not self.multiple:
             return country_to_text(value)
-        if isinstance(value, (basestring, Country)):
-            if isinstance(value, basestring) and "," in value:
+        if isinstance(value, (str, Country)):
+            if isinstance(value, str) and "," in value:
                 value = value.split(",")
             else:
                 value = [value]
@@ -398,7 +387,7 @@ class CountryField(CharField):
             return super(CountryField, self).to_python(value)
         if not value:
             return value
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value = value.split(",")
         output = []
         for item in value:

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -237,7 +237,7 @@ class LazyChoicesMixin(widgets.LazyChoicesMixin):
         """
         Also update the widget's choices.
         """
-        super(LazyChoicesMixin, self)._set_choices(value)
+        super()._set_choices(value)
         self.widget.choices = value
 
 
@@ -276,10 +276,10 @@ class CountryField(CharField):
             kwargs["max_length"] = len(self.countries) * 3 - 1
         else:
             kwargs["max_length"] = 2
-        super(CharField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def check(self, **kwargs):
-        errors = super(CountryField, self).check(**kwargs)
+        errors = super().check(**kwargs)
         errors.extend(self._check_multiple())
         return errors
 
@@ -305,12 +305,12 @@ class CountryField(CharField):
         return "CharField"
 
     def contribute_to_class(self, cls, name):
-        super(CountryField, self).contribute_to_class(cls, name)
+        super().contribute_to_class(cls, name)
         setattr(cls, self.name, self.descriptor_class(self))
 
     def pre_save(self, *args, **kwargs):
         "Returns field's value just before saving."
-        value = super(CharField, self).pre_save(*args, **kwargs)
+        value = super().pre_save(*args, **kwargs)
         return self.get_prep_value(value)
 
     def get_prep_value(self, value):
@@ -321,7 +321,7 @@ class CountryField(CharField):
                 value = ",".join(value)
             else:
                 value = ""
-        return super(CharField, self).get_prep_value(value)
+        return super().get_prep_value(value)
 
     def get_clean_value(self, value):
         if value is None:
@@ -348,7 +348,7 @@ class CountryField(CharField):
         Not including the ``blank_label`` property, as this isn't database
         related.
         """
-        name, path, args, kwargs = super(CountryField, self).deconstruct()
+        name, path, args, kwargs = super().deconstruct()
         kwargs.pop("choices")
         if self.multiple:  # multiple determines the length of the field
             kwargs["multiple"] = self.multiple
@@ -366,7 +366,7 @@ class CountryField(CharField):
                 blank_choice = [("", self.blank_label)]
         if self.multiple:
             include_blank = False
-        return super(CountryField, self).get_choices(
+        return super().get_choices(
             include_blank=include_blank, blank_choice=blank_choice, *args, **kwargs
         )
 
@@ -378,20 +378,20 @@ class CountryField(CharField):
             LazyTypedMultipleChoiceField if self.multiple else LazyTypedChoiceField,
         )
         if "coerce" not in kwargs:
-            kwargs["coerce"] = super(CountryField, self).to_python
-        field = super(CharField, self).formfield(**kwargs)
+            kwargs["coerce"] = super().to_python
+        field = super().formfield(**kwargs)
         return field
 
     def to_python(self, value):
         if not self.multiple:
-            return super(CountryField, self).to_python(value)
+            return super().to_python(value)
         if not value:
             return value
         if isinstance(value, str):
             value = value.split(",")
         output = []
         for item in value:
-            output.append(super(CountryField, self).to_python(item))
+            output.append(super().to_python(item))
         return output
 
     def validate(self, value, model_instance):
@@ -399,7 +399,7 @@ class CountryField(CharField):
         Use custom validation for when using a multiple countries field.
         """
         if not self.multiple:
-            return super(CountryField, self).validate(value, model_instance)
+            return super().validate(value, model_instance)
 
         if not self.editable:
             # Skip validation for non-editable fields.

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -26,7 +26,7 @@ def country_to_text(value):
     return force_str(value)
 
 
-class TemporaryEscape(object):
+class TemporaryEscape:
     __slots__ = ["country", "original_escape"]
 
     def __init__(self, country):
@@ -45,7 +45,7 @@ class TemporaryEscape(object):
         self.country._escape = self.original_escape
 
 
-class Country(object):
+class Country:
     def __init__(self, code, flag_url=None, str_attr="code", custom_countries=None):
         self.flag_url = flag_url
         self._escape = False
@@ -191,7 +191,7 @@ class Country(object):
         raise AttributeError()
 
 
-class CountryDescriptor(object):
+class CountryDescriptor:
     """
     A descriptor for country fields on a model instance. Returns a Country when
     accessed so you can do things like::

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -35,8 +35,6 @@ class TemporaryEscape:
     def __bool__(self):
         return self.country._escape
 
-    __nonzero__ = __bool__
-
     def __enter__(self):
         self.original_escape = self.country._escape
         self.country._escape = True

--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -23,7 +23,7 @@ class CountryFilter(admin.FieldListFilter):
         }
         for lookup, title in self.lookup_choices(changelist):
             yield {
-                "selected": value == force_text(lookup),
+                "selected": value == force_str(lookup),
                 "query_string": changelist.get_query_string(
                     {self.field.name: lookup}, []
                 ),

--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class CountryFilter(admin.FieldListFilter):

--- a/django_countries/serializer_fields.py
+++ b/django_countries/serializer_fields.py
@@ -1,7 +1,5 @@
-from __future__ import unicode_literals
-
 from rest_framework import serializers
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from django_countries import countries
 
@@ -19,7 +17,7 @@ class CountryField(serializers.ChoiceField):
             return ""
         if not self.country_dict:
             return code
-        return {"code": code, "name": force_text(self.countries.name(obj))}
+        return {"code": code, "name": force_str(self.countries.name(obj))}
 
     def to_internal_value(self, data):
         if not self.allow_blank and data == '':
@@ -29,7 +27,7 @@ class CountryField(serializers.ChoiceField):
             data = data.get("code")
         country = self.countries.alpha2(data)
         if data and not country:
-            country = self.countries.by_name(force_text(data))
+            country = self.countries.by_name(force_str(data))
             if not country:
                 self.fail("invalid_choice", input=data)
         return country

--- a/django_countries/serializer_fields.py
+++ b/django_countries/serializer_fields.py
@@ -9,7 +9,7 @@ class CountryField(serializers.ChoiceField):
         self.country_dict = kwargs.pop("country_dict", None)
         field_countries = kwargs.pop("countries", None)
         self.countries = field_countries if field_countries else countries
-        super(CountryField, self).__init__(self.countries, *args, **kwargs)
+        super().__init__(self.countries, *args, **kwargs)
 
     def to_representation(self, obj):
         code = self.countries.alpha2(obj)

--- a/django_countries/serializers.py
+++ b/django_countries/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 class CountryFieldMixin(object):
     def build_standard_field(self, field_name, model_field):
-        field_class, field_kwargs = super(CountryFieldMixin, self).build_standard_field(
+        field_class, field_kwargs = super().build_standard_field(
             field_name, model_field
         )
         if (

--- a/django_countries/serializers.py
+++ b/django_countries/serializers.py
@@ -2,7 +2,7 @@ from . import fields, serializer_fields
 from rest_framework import serializers
 
 
-class CountryFieldMixin(object):
+class CountryFieldMixin:
     def build_standard_field(self, field_name, model_field):
         field_class, field_kwargs = super().build_standard_field(
             field_name, model_field

--- a/django_countries/templatetags/countries.py
+++ b/django_countries/templatetags/countries.py
@@ -1,22 +1,16 @@
 import django
 from django import template
-from django_countries.fields import Country, countries
 
+from django_countries.fields import Country, countries
 
 register = template.Library()
 
-if django.VERSION < (1, 9):
-    # Support older versions without implicit assignment support in simple_tag.
-    simple_tag = register.assignment_tag
-else:
-    simple_tag = register.simple_tag
 
-
-@simple_tag
+@register.simple_tag
 def get_country(code):
     return Country(code=code)
 
 
-@simple_tag
+@register.simple_tag
 def get_countries():
     return list(countries)

--- a/django_countries/tests/test_admin_filters.py
+++ b/django_countries/tests/test_admin_filters.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.contrib import admin

--- a/django_countries/tests/test_admin_filters.py
+++ b/django_countries/tests/test_admin_filters.py
@@ -31,8 +31,8 @@ class TestCountryFilter(TestCase):
             kwargs.pop("list_max_show_all", m.list_max_show_all),
             kwargs.pop("list_editable", m.list_editable),
             m,
+            kwargs.pop("sortable_by", m.sortable_by),
         ]
-        args.append(kwargs.pop("sortable_by", m.sortable_by))
         assert not kwargs, "Unexpected kwarg %s" % kwargs
         return args
 

--- a/django_countries/tests/test_admin_filters.py
+++ b/django_countries/tests/test_admin_filters.py
@@ -32,8 +32,7 @@ class TestCountryFilter(TestCase):
             kwargs.pop("list_editable", m.list_editable),
             m,
         ]
-        if hasattr(m, "sortable_by"):  # Django 2.1+
-            args.append(kwargs.pop("sortable_by", m.sortable_by))
+        args.append(kwargs.pop("sortable_by", m.sortable_by))
         assert not kwargs, "Unexpected kwarg %s" % kwargs
         return args
 

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from django.test import TestCase
 from django.utils import translation
 

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -65,7 +65,7 @@ class TestCountriesObject(BaseTest):
         self.assertEqual(len(sliced), 5)
 
     def test_countries_custom_gettext_evaluation(self):
-        class FakeLazyGetText(object):
+        class FakeLazyGetText:
             def __bool__(self):  # pragma: no cover
                 raise ValueError("Can't evaluate lazy_gettext yet")
 

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -69,8 +69,6 @@ class TestCountriesObject(BaseTest):
             def __bool__(self):  # pragma: no cover
                 raise ValueError("Can't evaluate lazy_gettext yet")
 
-            __nonzero__ = __bool__
-
         with self.settings(COUNTRIES_OVERRIDE={"AU": FakeLazyGetText()}):
             countries.countries
 

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -64,14 +64,14 @@ class TestCountriesObject(BaseTest):
         sliced = countries[10:20:2]
         self.assertEqual(len(sliced), 5)
 
-    def test_countries_custom_ugettext_evaluation(self):
-        class FakeLazyUGetText(object):
+    def test_countries_custom_gettext_evaluation(self):
+        class FakeLazyGetText(object):
             def __bool__(self):  # pragma: no cover
-                raise ValueError("Can't evaluate lazy_ugettext yet")
+                raise ValueError("Can't evaluate lazy_gettext yet")
 
             __nonzero__ = __bool__
 
-        with self.settings(COUNTRIES_OVERRIDE={"AU": FakeLazyUGetText()}):
+        with self.settings(COUNTRIES_OVERRIDE={"AU": FakeLazyGetText()}):
             countries.countries
 
     def test_ioc_countries(self):

--- a/django_countries/tests/test_drf.py
+++ b/django_countries/tests/test_drf.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.test import TestCase, override_settings
 
 from django_countries import countries

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import pickle
 import tempfile
+from unittest import mock
 
 from django.db import models
 from django.core import validators, checks
@@ -10,17 +9,13 @@ from django.forms import Select
 from django.forms.models import modelform_factory
 from django.test import TestCase, override_settings
 from django.utils import translation
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from django_countries import fields, countries, data
 from django_countries.fields import CountryField
 from django_countries.tests import forms, custom_countries
 from django_countries.tests.models import Person, AllowNull, MultiCountry, WithProp
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class TestCountryField(TestCase):
@@ -46,7 +41,7 @@ class TestCountryField(TestCase):
 
     def test_text(self):
         person = Person(name="Chris Beaven", country="NZ")
-        self.assertEqual(force_text(person.country), "NZ")
+        self.assertEqual(force_str(person.country), "NZ")
 
     def test_name(self):
         person = Person(name="Chris Beaven", country="NZ")

--- a/django_countries/tests/test_settings.py
+++ b/django_countries/tests/test_settings.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-import six
 from django.test import TestCase
 
 from django_countries import countries, data, base
@@ -47,12 +45,10 @@ class TestSettings(TestCase):
 
     def test_common_names(self):
         common_code, common_name = list(base.CountriesBase.COMMON_NAMES.items())[0]
-        common_name = six.text_type(common_name)
-        name = six.text_type(countries.countries[common_code])
-        self.assertEqual(name, common_name)
+        self.assertEqual(countries.countries[common_code], common_name)
 
         del countries.countries
-        official_name = six.text_type(data.COUNTRIES[common_code])
+        official_name = data.COUNTRIES[common_code]
         with self.settings(COUNTRIES_COMMON_NAMES=False):
-            name = six.text_type(countries.countries[common_code])
+            name = countries.countries[common_code]
             self.assertEqual(name, official_name)

--- a/django_countries/tests/test_widgets.py
+++ b/django_countries/tests/test_widgets.py
@@ -1,12 +1,7 @@
-from __future__ import unicode_literals
-from unittest import skipIf
-
-try:
-    from urllib import parse as urlparse
-except ImportError:
-    import urlparse  # Python 2
-
 from distutils.version import StrictVersion
+from unittest import skipIf
+from urllib import parse as urlparse
+
 import django
 from django.forms.models import modelform_factory
 from django.test import TestCase

--- a/django_countries/tests/test_widgets.py
+++ b/django_countries/tests/test_widgets.py
@@ -1,8 +1,5 @@
-from distutils.version import StrictVersion
-from unittest import skipIf
 from urllib import parse as urlparse
 
-import django
 from django.forms.models import modelform_factory
 from django.test import TestCase
 from django.utils import safestring
@@ -60,10 +57,6 @@ class TestCountrySelectWidget(TestCase):
         person = Person(country="NZ")
         self.Form(instance=person).as_p()
 
-    @skipIf(
-        StrictVersion(django.get_version()) < StrictVersion("1.10"),
-        "required attribute only implemented in 1.10+",
-    )
     def test_required_attribute(self):
         rendered = self.Form()["country"].as_widget()
         rendered = rendered[: rendered.find(">") + 1]

--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -77,11 +77,7 @@ class CountrySelectWidget(LazySelect):
             )
         else:
             flag_id = ""
-        # Renderer argument only added in 1.11, keeping backwards compat.
-        kwargs = {"renderer": renderer} if renderer else {}
-        widget_render = super().render(
-            name, value, attrs, **kwargs
-        )
+        widget_render = super().render(name, value, attrs, renderer=renderer)
         if isinstance(value, Country):
             country = value
         else:

--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -1,10 +1,5 @@
-from __future__ import unicode_literals
-
-try:
-    from urllib import parse as urlparse
-except ImportError:
-    import urlparse  # Python 2
 import copy
+from urllib import parse as urlparse
 
 from django.forms import widgets
 from django.utils.html import escape

--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -63,7 +63,7 @@ class CountrySelectWidget(LazySelect):
             'style="margin: 6px 4px 0" '
             'src="{country.flag}">'
         )
-        super(CountrySelectWidget, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, renderer=None):
         from django_countries.fields import Country
@@ -79,7 +79,7 @@ class CountrySelectWidget(LazySelect):
             flag_id = ""
         # Renderer argument only added in 1.11, keeping backwards compat.
         kwargs = {"renderer": renderer} if renderer else {}
-        widget_render = super(CountrySelectWidget, self).render(
+        widget_render = super().render(
             name, value, attrs, **kwargs
         )
         if isinstance(value, Country):

--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -16,7 +16,7 @@ COUNTRY_CHANGE_HANDLER = (
 )
 
 
-class LazyChoicesMixin(object):
+class LazyChoicesMixin:
     @property
     def choices(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,19 +15,17 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
-    Framework :: Django
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Framework :: Django :: 2.2
+    Framework :: Django :: 3.0
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
-install_requires =
-    six
-
 
 [options.extras_require]
 maintainer =
@@ -85,4 +83,4 @@ ignore-bad-ideas = *.mo
 DJANGO_SETTINGS_MODULE = django_countries.tests.settings
 filterwarnings =
     module
-    ignore:force_text|smart_text|django.utils.translation.ugettext_lazy:PendingDeprecationWarning
+    ignore:force_str|smart_text|django.utils.translation.ugettext_lazy:PendingDeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-countries
-version = 5.6.dev0
+version = 6.0.dev0
 description = Provides a country field for Django models.
 long_description = file: README.rst, CHANGES.rst
 author = Chris Beaven
@@ -15,10 +15,12 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Framework :: Django
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
 
@@ -35,12 +37,10 @@ maintainer =
 dev =
     tox
     django
-    mock; python_version<"3"
     pytest
     pytest-django
     djangorestframework
 test =
-    mock; python_version<"3"
     pytest
     pytest-django
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,6 @@ test =
     pytest-django
     pytest-cov
 
-[bdist_wheel]
-# Works in both Python 2 and Python 3
-universal = 1
-
 [flake8]
 exclude =
     .tox,

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,3 @@ ignore-bad-ideas = *.mo
 
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = django_countries.tests.settings
-filterwarnings =
-    module
-    ignore:force_str|smart_text|django.utils.translation.ugettext_lazy:PendingDeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ distribute = False
 envlist =
     coverage_setup
     # Pyuca
-    py37-django30-drf310-pyuca
+    py38-django30-drf311-pyuca
     # Latest
     py38-django30-drf311
     # Historical
@@ -40,7 +40,7 @@ deps =
     drf311: djangorestframework==3.11.*
     pyuca: pyuca
     django22: Django==2.2.*
-    django30: Django==3.0
+    django30: Django==3.0.*
     djangonext: Django
 commands = pytest --cov --cov-append --cov-report=
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,8 @@ envlist =
     py38-django30-drf311
     # Historical
     py35-django{22}-drf{37,38}
-    py36-django{22}-drf{37,38,39}
-    py36-django{30}-drf{310,311}
-    py37-django{22}-drf{37,38,39}
-    py37-django{30}-drf{310,311}
-    py38-django{22}-drf{37,38,39}
-    py38-django{30}-drf{310,311}
+    py{36,37,38}-django{22}-drf{37,38,39}
+    py{36,37,38}-django{30}-drf{310,311}
     readme
     bandit
     coverage_report

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,17 @@ distribute = False
 envlist =
     coverage_setup
     # Pyuca
-    py36-django22-drf39-pyuca
-    py27-django111-drf33-pyuca
+    py37-django30-drf310-pyuca
     # Latest
-    py37-django22-drf39
+    py38-django30-drf311
     # Historical
-    py36-django{111,20,21}-drf{37,38,39}
-    py27-django111-drf{37,38,39}
-    py27-django18-drf{33,34,35,36}
+    py35-django{22}-drf{37,38}
+    py36-django{22}-drf{37,38,39}
+    py36-django{30}-drf{310,311}
+    py37-django{22}-drf{37,38,39}
+    py37-django{30}-drf{310,311}
+    py38-django{22}-drf{37,38,39}
+    py38-django{30}-drf{310,311}
     readme
     bandit
     coverage_report
@@ -18,11 +21,10 @@ skip_missing_interpreters = True
 
 [travis]
 python =
-    2.7: py27, readme, codecov
-    3.4: py34, codecov
     3.5: py35, codecov
     3.6: py36, codecov
     3.7: py37, bandit, codecov
+    3.8: py38, bandit, codecov
 
 
 [testenv]
@@ -31,25 +33,20 @@ extras = test
 setenv =
     DJANGO_SETTINGS_MODULE = django_countries.tests.settings
 deps =
-    drf33: djangorestframework==3.3.*
-    drf34: djangorestframework==3.4.*
-    drf35: djangorestframework==3.5.*
-    drf36: djangorestframework==3.6.*
     drf37: djangorestframework==3.7.*
     drf38: djangorestframework==3.8.*
     drf39: djangorestframework==3.9.*
+    drf310: djangorestframework==3.10.*
+    drf311: djangorestframework==3.11.*
     pyuca: pyuca
-    django18: Django==1.8.*
-    django111: Django==1.11.*
-    django20: Django==2.0.*
-    django21: Django==2.1.*
     django22: Django==2.2.*
+    django30: Django==3.0
     djangonext: Django
 commands = pytest --cov --cov-append --cov-report=
 
 [testenv:readme]
 skip_install = True
-basepython = python2.7
+basepython = python3.8
 deps =
     docutils
     Pygments

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ python =
     3.5: py35, codecov
     3.6: py36, codecov
     3.7: py37, bandit, codecov
-    3.8: py38, bandit, codecov
+    3.8: py38, bandit, codecov, readme
 
 
 [testenv]


### PR DESCRIPTION
Overlaps with #279 , #285, #286, #287, #290 in preparing for Django 3 and deprecating Python 2.

---

This is intended as a prototype to demonstrate what `django-countries` would look like if it dropped support for Python 2 and Django 1.x when moving to Django 3 support (I totally understand @SmileyChris' desire to continue to support legacy versions, and am happy for the PR to be closed without merging) - its main purpose is discussion / reference.

One thing that worth pointing out is the Django <> DRF test matrix. In version 3.7/8/9 DRF relies on the Django vendored version of `six` which was dropped in Django 3.0. Hence specifying DRF 3.10/11 for the Django 3.0 tests.

| Python | Django 2.2 | Django 3.0 |
|---|:--|:--|
| 3.5 | DRF: 3.7, 3.8 | n/a |
| 3.6 | DRF: 3.7, 3.8, 3.9 | 3.10, 3.11 |
| 3.7 | DRF: 3.7, 3.8, 3.9 | 3.10, 3.11 |
| 3.8 | DRF: 3.7, 3.8, 3.9 | 3.10, 3.11 |

#### Changes

* Remove use of `six` across the project
* Replace `force_text` with `force_str`
* Remove conditional Py2/3 import statements in favour of Py3 only
* Replace `mock` with `unittest.mock`
* Update `super(Klass, self)` to `super()` syntax
* Remove `__future__.unicode_literals` imports
* Update tox test configuration
* Update travis CI configuration
* Update classifiers in `setup.cfg`
* Replace `ugettext` with `gettext` (deprecated in Django 4.0, and already just an alias)