### PR TITLE
Remove double space from Falkland Islands [Malvinas]

### DIFF
--- a/django_countries/data.py
+++ b/django_countries/data.py
@@ -101,7 +101,7 @@ COUNTRIES = {
     "EE": _("Estonia"),
     "SZ": _("Eswatini"),
     "ET": _("Ethiopia"),
-    "FK": _("Falkland Islands  [Malvinas]"),
+    "FK": _("Falkland Islands [Malvinas]"),
     "FO": _("Faroe Islands"),
     "FJ": _("Fiji"),
     "FI": _("Finland"),


### PR DESCRIPTION
The double space looks like a typo and it causes failures in our app tests where we compare output of the application (with normalized spaces) with CountryField data on model.