### PR TITLE
Add support for serializer fields with country name only

### DIFF
--- a/django_countries/serializer_fields.py
+++ b/django_countries/serializer_fields.py
@@ -7,6 +7,7 @@ from django_countries import countries
 class CountryField(serializers.ChoiceField):
     def __init__(self, *args, **kwargs):
         self.country_dict = kwargs.pop("country_dict", None)
+        self.name_only = kwargs.pop("name_only", None)
         field_countries = kwargs.pop("countries", None)
         self.countries = field_countries if field_countries else countries
         super().__init__(self.countries, *args, **kwargs)
@@ -15,6 +16,8 @@ class CountryField(serializers.ChoiceField):
         code = self.countries.alpha2(obj)
         if not code:
             return ""
+        if self.name_only:
+            return force_str(self.countries.name(obj))
         if not self.country_dict:
             return code
         return {"code": code, "name": force_str(self.countries.name(obj))}


### PR DESCRIPTION
Thanks for this package! I've been using it and it has been very helpful. That said, there was a specific use case related to `django-rest-framework` that didn't seem to be supported. Here's my proposed implementation. 

When using this package with `django-rest-framework`, we have two alternatives of seeing country fields:

- **Code Only (default)**

```
from django_countries.serializer_fields import CountryField

class CountrySerializer(serializers.Serializer):
    country = CountryField()

```

This returns a response of the type `{"country": "UK"} `


- **Code and Name**
```
from django_countries.serializer_fields import CountryField

class CountrySerializer(serializers.Serializer):
    country = CountryField(country_dict=True)

```

This returns a response of the type `{"country": {"code": "UK", "name": "United Kingdom"} `

This PR adds support for a **third alternative**, that was necessary in my case and I imagine is a common use case:
- **Name only**
```
from django_countries.serializer_fields import CountryField

class CountrySerializer(serializers.Serializer):
    country = CountryField(name_only=True)

```

This returns a response of the type `{"country": "United Kingdom"} `