### PR TITLE
Implementation of 'countries_str_attr' on CountryField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ var/
 *.egg
 
 # PyInstaller
-#  Usually these files are written by a python script from a template 
+#  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
@@ -60,6 +60,9 @@ ehthumbs.db
 Icon?
 Thumbs.db
 
-
 # PyCharm
 /.idea/
+
+# Virtual environment
+venv/
+virtualenv/

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -214,6 +214,7 @@ class CountryDescriptor:
         return Country(
             code=code,
             flag_url=self.field.countries_flag_url,
+            str_attr=self.field.countries_str_attr,
             custom_countries=self.field.countries,
         )
 
@@ -266,6 +267,7 @@ class CountryField(CharField):
         countries_class = kwargs.pop("countries", None)
         self.countries = countries_class() if countries_class else countries
         self.countries_flag_url = kwargs.pop("countries_flag_url", None)
+        self.countries_str_attr = kwargs.pop("countries_str_attr", "code")
         self.blank_label = kwargs.pop("blank_label", None)
         self.multiple = kwargs.pop("multiple", None)
         kwargs["choices"] = self.countries

--- a/django_countries/tests/models.py
+++ b/django_countries/tests/models.py
@@ -9,6 +9,7 @@ class Person(models.Model):
     other_country = CountryField(
         blank=True, countries_flag_url="//flags.example.com/{code}.gif"
     )
+    str_attr_country = CountryField(blank=True, countries_str_attr="name")
     favourite_country = CountryField(default="NZ")
     fantasy_country = CountryField(
         countries=custom_countries.FantasyCountries, blank=True

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -55,6 +55,10 @@ class TestCountryField(TestCase):
         person = Person(name="Chris Beaven", country="NZ", other_country="US")
         self.assertEqual(person.other_country.flag, "//flags.example.com/us.gif")
 
+    def test_custom_field_str_attr(self):
+        person = Person(name="Quentin Coumes", country="FR", str_attr_country="ES")
+        self.assertEqual(str(person.str_attr_country), "Spain")
+
     def test_unicode_flags(self):
         person = Person(name="Matthew Schinckel", country="AU", other_country="DE")
         self.assertEqual(person.country.unicode_flag, "🇦🇺")


### PR DESCRIPTION
Following #324, this PR allow to define `str_attr` argument of `Country` in `CountryField` using `countries_str_attr` keyword argument.