### PR TITLE
Remove superfluous and incorrect super() arguments

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -279,7 +279,7 @@ class CountryField(CharField):
                 kwargs["max_length"] = len(self.countries) * 3 - 1
             else:
                 kwargs["max_length"] = 2
-        super(CharField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def check(self, **kwargs):
         errors = super().check(**kwargs)
@@ -313,7 +313,7 @@ class CountryField(CharField):
 
     def pre_save(self, *args, **kwargs):
         "Returns field's value just before saving."
-        value = super(CharField, self).pre_save(*args, **kwargs)
+        value = super().pre_save(*args, **kwargs)
         return self.get_prep_value(value)
 
     def get_prep_value(self, value):
@@ -324,7 +324,7 @@ class CountryField(CharField):
                 value = ",".join(value)
             else:
                 value = ""
-        return super(CharField, self).get_prep_value(value)
+        return super().get_prep_value(value)
 
     def get_clean_value(self, value):
         if value is None:


### PR DESCRIPTION
The CountryField uses super() in a few methods to call base class methods. However, it incorrectly used the superclass of \_CharField\_ instead of the superclass of \_CountryField\_, thereby skipping one level in the inheritance hierarchy.

I found this while upgrading a project to Django 3.2a1, where CharField.\_\_init__ sets self.db_collation and CharField.deconstruct reads the aforementioned attribute, producing a crash because CountryField.\_\_init__ doesn't actually run CharField.\_\_init__ at all.