### PR TITLE
Add support for the upcoming Django 3.2

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -351,7 +351,7 @@ class CountryField(CharField):
         Not including the ``blank_label`` property, as this isn't database
         related.
         """
-        name, path, args, kwargs = super().deconstruct()
+        name, path, args, kwargs = super(CharField, self).deconstruct()
         kwargs.pop("choices")
         if self.multiple:  # multiple determines the length of the field
             kwargs["multiple"] = self.multiple

--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -8,6 +8,7 @@ INSTALLED_APPS = (
 )
 
 DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 STATIC_URL = "/static-assets/"
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist =
     # Latest
     latest{-pyuca,}
     # Historical Python, Django and DRF versions
-    py{36,37,38}-django{111,22,30}-drf{310,311}
-    # Legacy pyuca 
+    py{36,37,38}-django{111,22,30,31}-drf{310,311}
+    # Legacy pyuca
     legacy-pyuca
     # Package checks
     readme
@@ -38,7 +38,8 @@ deps =
     django111,legacy: Django==1.11.*
     django22: Django==2.2.*
     django30: Django==3.0.*
-    django31,latest: Django==3.1.*
+    django31: Django==3.1.*
+    django32,latest: Django>=3.2a1,<4.0
     coverage_setup,coverage_report: coverage
 depends = coverage_setup
 commands = pytest --cov --cov-append --cov-report=

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ envlist =
     # Latest
     latest{-pyuca,}
     # Historical Python, Django and DRF versions
-    py{36,37,38}-django{111,22,30,31}-drf{310,311}
+    py{36,37,38}-django{111,22,30}-drf{310,311}
+    py{36,37,38}-django{31}-drf{311}
     # Legacy pyuca
     legacy-pyuca
     # Package checks


### PR DESCRIPTION
The CountryField uses super() in a few methods to skip CharField's methods and call methods of the CharField's superclass directly. Django 3.2 adds support for db_collation to CharField, but the CountryField doesn't need this. Since CountryField.\_\_init__ does not call CharField.\_\_init__, CountryField.deconstruct shouldn't call CharField.deconstruct either.

Also, Django 3.1 and django-rest-framework 3.10.x are not compatible because django-rest-framework imports the `FieldDoesNotExist` exception from location where it isn't available anymore in Django 3.1. Therefore, this pull request also removes this combination from the CI matrix.

Replaces #328