### PR TITLE
Update subclass use of super(...)

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -313,7 +313,7 @@ class CountryField(CharField):
 
     def pre_save(self, *args, **kwargs):
         "Returns field's value just before saving."
-        value = super().pre_save(*args, **kwargs)
+        value = super(CharField, self).pre_save(*args, **kwargs)
         return self.get_prep_value(value)
 
     def get_prep_value(self, value):
@@ -324,7 +324,7 @@ class CountryField(CharField):
                 value = ",".join(value)
             else:
                 value = ""
-        return super().get_prep_value(value)
+        return super(CharField, self).get_prep_value(value)
 
     def get_clean_value(self, value):
         if value is None:
@@ -351,7 +351,7 @@ class CountryField(CharField):
         Not including the ``blank_label`` property, as this isn't database
         related.
         """
-        name, path, args, kwargs = super().deconstruct()
+        name, path, args, kwargs = super(CharField, self).deconstruct()
         kwargs.pop("choices")
         if self.multiple:  # multiple determines the length of the field
             kwargs["multiple"] = self.multiple

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -279,7 +279,7 @@ class CountryField(CharField):
                 kwargs["max_length"] = len(self.countries) * 3 - 1
             else:
                 kwargs["max_length"] = 2
-        super(CharField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def check(self, **kwargs):
         errors = super().check(**kwargs)
@@ -313,7 +313,7 @@ class CountryField(CharField):
 
     def pre_save(self, *args, **kwargs):
         "Returns field's value just before saving."
-        value = super(CharField, self).pre_save(*args, **kwargs)
+        value = super().pre_save(*args, **kwargs)
         return self.get_prep_value(value)
 
     def get_prep_value(self, value):
@@ -324,7 +324,7 @@ class CountryField(CharField):
                 value = ",".join(value)
             else:
                 value = ""
-        return super(CharField, self).get_prep_value(value)
+        return super().get_prep_value(value)
 
     def get_clean_value(self, value):
         if value is None:
@@ -351,7 +351,7 @@ class CountryField(CharField):
         Not including the ``blank_label`` property, as this isn't database
         related.
         """
-        name, path, args, kwargs = super(CharField, self).deconstruct()
+        name, path, args, kwargs = super().deconstruct()
         kwargs.pop("choices")
         if self.multiple:  # multiple determines the length of the field
             kwargs["multiple"] = self.multiple

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -1,6 +1,6 @@
 import pickle
 import tempfile
-from unittest import mock, skipUnless
+from unittest import mock
 
 import django
 from django.db import models
@@ -11,16 +11,16 @@ from django.forms.models import modelform_factory
 from django.test import TestCase, override_settings
 from django.utils import translation
 from django.utils.encoding import force_str
-from packaging import version
 
 from django_countries import fields, countries, data
 from django_countries.fields import CountryField
 from django_countries.tests import forms, custom_countries
 from django_countries.tests.models import Person, AllowNull, MultiCountry, WithProp
 
-
-def has_db_collation() -> bool:
-    return version.parse(django.get_version()) >= version.parse("3.2")
+# Django 3.2 introduced a db_collation attr on fields.
+def has_db_collation():
+    major, minor = django.VERSION[0:2]
+    return (major > 3) or (major==3 and minor >=2)
 
 
 class TestCountryField(TestCase):

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -1,7 +1,7 @@
 import pickle
 import tempfile
-from packaging import version
 from unittest import mock
+from unittest.case import skipUnless
 
 import django
 from django.db import models
@@ -18,17 +18,20 @@ from django_countries.fields import CountryField
 from django_countries.tests import forms, custom_countries
 from django_countries.tests.models import Person, AllowNull, MultiCountry, WithProp
 
-# Django introduced a db_collation attr on CharFields in 3.2
-DJANGO_VERSION = version.parse(django.get_version())
-HAS_DB_COLLATION = DJANGO_VERSION >= version.parse("3.2a1")
+
+# Django 3.2 introduced a db_collation attr on fields.
+def has_db_collation():
+    major, minor = django.VERSION[0:2]
+    return (major > 3) or (major==3 and minor >=2)
 
 
 class TestCountryField(TestCase):
 
+    @skipUnless(has_db_collation(), "Django version < 3.2")
     def test_db_collation(self):
         # test fix for issue 338
         country = fields.CountryField()
-        self.assertEqual(hasattr(country, "db_collation"), HAS_DB_COLLATION)
+        self.assertTrue(hasattr(country, "db_collation"))
 
     def test_logic(self):
         person = Person(name="Chris Beaven", country="NZ")

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -1,7 +1,8 @@
 import pickle
 import tempfile
-from unittest import mock
+from unittest import mock, skipUnless
 
+import django
 from django.db import models
 from django.core import validators, checks
 from django.core.management import call_command
@@ -10,6 +11,7 @@ from django.forms.models import modelform_factory
 from django.test import TestCase, override_settings
 from django.utils import translation
 from django.utils.encoding import force_str
+from packaging import version
 
 from django_countries import fields, countries, data
 from django_countries.fields import CountryField
@@ -17,7 +19,17 @@ from django_countries.tests import forms, custom_countries
 from django_countries.tests.models import Person, AllowNull, MultiCountry, WithProp
 
 
+def has_db_collation() -> bool:
+    return version.parse(django.get_version()) >= version.parse("3.2")
+
+
 class TestCountryField(TestCase):
+
+    def test_db_collation(self):
+        # test fix for issue 338
+        country = fields.CountryField()
+        self.assertEqual(hasattr(country, "db_collation"), has_db_collation())
+
     def test_logic(self):
         person = Person(name="Chris Beaven", country="NZ")
 

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -1,5 +1,6 @@
 import pickle
 import tempfile
+from packaging import version
 from unittest import mock
 
 import django
@@ -17,10 +18,9 @@ from django_countries.fields import CountryField
 from django_countries.tests import forms, custom_countries
 from django_countries.tests.models import Person, AllowNull, MultiCountry, WithProp
 
-# Django 3.2 introduced a db_collation attr on fields.
-def has_db_collation():
-    major, minor = django.VERSION[0:2]
-    return (major > 3) or (major==3 and minor >=2)
+# Django introduced a db_collation attr on CharFields in 3.2
+DJANGO_VERSION = version.parse(django.get_version())
+HAS_DB_COLLATION = DJANGO_VERSION >= version.parse("3.2a1")
 
 
 class TestCountryField(TestCase):
@@ -28,7 +28,7 @@ class TestCountryField(TestCase):
     def test_db_collation(self):
         # test fix for issue 338
         country = fields.CountryField()
-        self.assertEqual(hasattr(country, "db_collation"), has_db_collation())
+        self.assertEqual(hasattr(country, "db_collation"), HAS_DB_COLLATION)
 
     def test_logic(self):
         person = Person(name="Chris Beaven", country="NZ")


### PR DESCRIPTION
Fixes #338 

This arose out of running tests with Django 3.2b1. The initialisation of the `CountryField` calls `super(CharField, self).__init__(...)` which doesn't actually call the parent method, and so the `db_collation` attr is never set.

The init call should either use the subclass itself `super(CountryField, self)`, or just go with `super()`.

```python
class Foo:
    def __init__(self):
        self.db_collation = ""


class Bar(Foo):
    # does *not* set the collation
    def __init__(self):
        super(Foo, self).__init__()


class Baz(Foo):
    def __init__(self):
        super(Baz, self).__init__()


class Bob(Foo):
    def __init__(self):
        super().__init__()


def test_foo():
    for klass, db_collation in [
        (Foo, True),
        (Bar, False),
        (Baz, True),
        (Bob, True),
    ]:
        obj = klass()
        assert hasattr(obj, "db_collation") == db_collation
```

NB for some reason the `CountryField.get_prep_value` method _requires_ that it is `super(CharField, self)` - 4 tests fail without it.