### PR TITLE
Migrate CI to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: pip install tox tox-gh-actions
+
+    - name: Tox tests
+      run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.9"
-install: pip install tox-travis
-script: tox

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,9 @@ Django Countries
     :alt: PyPI version
     :target: https://badge.fury.io/py/django-countries
 
-.. image:: https://travis-ci.org/SmileyChris/django-countries.svg?branch=master
+.. image:: https://img.shields.io/github/workflow/status/SmileyChris/django-countries/CI?label=CI&logo=github
     :alt: Build status
-    :target: http://travis-ci.org/SmileyChris/django-countries
+    :target: https://github.com/SmileyChris/django-countries/actions?query=workflow%3ACI
 
 .. image:: https://codecov.io/gh/SmileyChris/django-countries/branch/master/graph/badge.svg
     :alt: Coverage status

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist =
 skip_missing_interpreters = True
 ignore_basepython_conflict = True
 
-[travis]
+[gh-actions]
 python =
     3.6: py36, legacy, codecov
     3.7: py37, codecov
@@ -83,7 +83,7 @@ commands =
 [testenv:codecov]
 skip_install = True
 deps = codecov
-passenv = CI TRAVIS TRAVIS_*
+passenv = CI GITHUB GITHUB_*
 commands = codecov
 
 [testenv:bandit]

--- a/tox.ini
+++ b/tox.ini
@@ -99,4 +99,4 @@ deps =
     django-stubs
     djangorestframework-stubs
 depends =
-commands = mypy django_countries
+commands = mypy --install-types --non-interactive django_countries

--- a/tox.ini
+++ b/tox.ini
@@ -76,9 +76,9 @@ depends =
     {latest,legacy}{-pyuca,}
     py{36,37,38,39}-django{22,30,31}-drf{310,311,312}{-pyuca,}
 commands =
-  coverage html
-  coverage report --include="django_countries/tests/*" --fail-under=100 -m
-  coverage report --omit="django_countries/tests/*" --fail-under=90 -m
+    coverage html
+    coverage report --include="django_countries/tests/*" --fail-under=100 -m
+    coverage report --omit="django_countries/tests/*" --fail-under=90 -m
 
 [testenv:codecov]
 skip_install = True


### PR DESCRIPTION
From https://travis-ci.org/github/SmileyChris/django-countries

<img width="1073" alt="image" src="https://user-images.githubusercontent.com/861044/131717222-d00cd17a-12b1-48c6-a44f-47988e4c67dd.png">

Travis CI is no longer working, this is an attempt at moving the CI to GitHub actions. I've attempted to change the minimum amount of things compared to the current setup.

Due to GitHub security limitations, workflows added from forks won't run on a pull request (hence no status), but you can see the results [here](https://github.com/browniebroke/django-countries/actions).