### PR TITLE
fix: use typing.Set for python <3.9 compatibility

### DIFF
--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -9,6 +9,7 @@ from typing import (
     Literal,
     NamedTuple,
     Optional,
+    Set,
     Tuple,
     Union,
     overload,
@@ -377,7 +378,7 @@ class Countries(CountriesBase):
         language: str = "en",
         insensitive: bool = True,
         regex: Literal[True] = False,
-    ) -> set[str]:
+    ) -> Set[str]:
         ...
 
     def by_name(
@@ -386,7 +387,7 @@ class Countries(CountriesBase):
         language: str = "en",
         insensitive: bool = True,
         regex: bool = False,
-    ) -> Union[str, set[str]]:
+    ) -> Union[str, Set[str]]:
         """
         Fetch a country's ISO3166-1 two letter country code from its name.
 


### PR DESCRIPTION
the use of `set[str]` is not supported in python < 3.9

The tests also catch that, so maybe there is an issue with the CI setup?