### PR TITLE
Fix translation of common names

### DIFF
--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -241,30 +241,11 @@ class Countries(CountriesBase):
         if isinstance(name, dict):
             if "names" in name:
                 country_name: str = name["names"][0]
-                fallback_names: List[str] = name["names"][1:]
             else:
                 country_name = name["name"]
-                fallback_names = []
         else:
             country_name = name
-            fallback_names = self.shadowed_names.get(code, [])
-        language = get_language()
-        if language and language.split("-")[0] != "en" and fallback_names:
-            # Check if there's an older translation available if there's no
-            # translation for the newest name.
-            with override("en"):
-                source_name = force_str(country_name)
-            country_name = force_str(country_name)
-            if country_name == source_name:
-                for fallback_name in fallback_names:
-                    with override("en"):
-                        source_fallback_name = force_str(fallback_name)
-                    fallback_name = force_str(fallback_name)
-                    if fallback_name != source_fallback_name:
-                        country_name = fallback_name
-                        break
-        else:
-            country_name = force_str(country_name)
+        country_name = force_str(country_name)
         return CountryTuple(code, country_name)
 
     def __iter__(self):

--- a/django_countries/tests/custom_countries.py
+++ b/django_countries/tests/custom_countries.py
@@ -6,11 +6,6 @@ class FantasyCountries(Countries):
     only = ["NZ", ("NV", "Neverland")]
 
 
-class TranslationFallbackCountries(Countries):
-    COMMON_NAMES = {"YE": "YYYemen"}
-    OLD_NAMES = {"NZ": [_("New Zealand")]}
-
-
 class GBRegionCountries(Countries):
     override = {
         "GB": None,

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -328,58 +328,15 @@ class CountriesFirstTest(BaseTest):
             finally:
                 translation.activate(lang)
 
-    def test_translation_fallback_from_common_name(self):
-        trans_fall_countries = custom_countries.TranslationFallbackCountries()
-        self.assertEqual(trans_fall_countries.name("YE"), "YYYemen")
+    def test_translation_common_name(self):
+        self.assertEqual(countries.name("VE"), "Venezuela")
         lang = translation.get_language()
-        translation.activate("eo")
-        try:
-            self.assertEqual(trans_fall_countries.name("YE"), "Jemeno")
-        finally:
-            translation.activate(lang)
-
-    def test_translation_fallback_from_old_name(self):
-        trans_fall_countries = custom_countries.TranslationFallbackCountries()
-        trans_fall_countries.countries["NZ"] = "Old Zealand"
-
-        self.assertEqual(trans_fall_countries.name("NZ"), "Old Zealand")
-        lang = translation.get_language()
-        translation.activate("eo")
-        try:
-            self.assertEqual(trans_fall_countries.name("NZ"), "Nov-Zelando")
-        finally:
-            translation.activate(lang)
-
-    def test_translation_fallback_no_override(self):
-        lang = translation.get_language()
-        translation.activate("eo")
+        translation.activate("de")
 
         try:
-            self.assertEqual(countries.name("NZ"), "Nov-Zelando")
-            self.assertEqual(countries.name("YE"), "Jemeno")
-
-            with self.settings(COUNTRIES_OVERRIDE={"NZ": "Hobbiton", "YE": "YYemen"}):
-                del countries.countries
-                self.assertEqual(countries.name("NZ"), "Hobbiton")
-                self.assertEqual(countries.name("YE"), "YYemen")
+            self.assertEqual(countries.name("VE"), "Venezuela")
         finally:
             translation.activate(lang)
-
-    def test_translation_fallback_override_names(self):
-        with self.settings(
-            COUNTRIES_OVERRIDE={
-                "NZ": {"names": ["Hobbiton", translation.gettext_lazy("New Zealand")]}
-            }
-        ):
-
-            self.assertEqual(countries.name("NZ"), "Hobbiton")
-            lang = translation.get_language()
-            translation.activate("eo")
-
-            try:
-                self.assertEqual(countries.name("NZ"), "Nov-Zelando")
-            finally:
-                translation.activate(lang)
 
     def test_first_multiple_labels(self):
         with self.settings(


### PR DESCRIPTION
The translation of a string to a different language may very well be
the same string. For example, the German translation of the English
word "Venezuela" is "Venezuela".

This means, we cannot rely on string equality as a way to check whether
a translation for a string is available.

Therefore, let's remove the usage of fallback names as suggested by
@SmileyChris.

Fixes: https://github.com/SmileyChris/django-countries/issues/364