### PR TITLE
docs: fix simple typo, instanciate -> instantiate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -500,7 +500,7 @@ REST output format
 ^^^^^^^^^^^^^^^^^^
 
 By default, the field will output just the country code. To output the full
-country name instead, instanciate the field with ``name_only=True``.
+country name instead, instantiate the field with ``name_only=True``.
 
 If you would rather have more verbose output, instantiate the field with
 ``country_dict=True``, which will result in the field having the following


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `instantiate` rather than `instanciate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md