### PR TITLE
fix IOC code singapore

### DIFF
--- a/django_countries/ioc_data.py
+++ b/django_countries/ioc_data.py
@@ -165,7 +165,7 @@ IOC_TO_ISO = {
     "SLE": "SL",
     "SLO": "SI",
     "SMR": "SM",
-    "SNG": "SG",
+    "SGP": "SG",
     "SOL": "SB",
     "SOM": "SO",
     "SRB": "RS",


### PR DESCRIPTION
should be only known by historic code SIN or the new code SGP. SNG is an unknown IOC code.
https://en.wikipedia.org/wiki/List_of_IOC_country_codes