### PR TITLE
always strip duplicate countries

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -1,4 +1,5 @@
 import re
+from collections import OrderedDict
 from typing import Any, Iterable, Optional, Tuple, Type, Union, cast
 from urllib import parse as urlparse
 
@@ -353,6 +354,7 @@ class CountryField(CharField):
                 iter(value)
             except TypeError:
                 value = [value]
+        value = list(OrderedDict.fromkeys(value))  # remove duplicates while maintaining order
         return list(filter(None, [self.country_to_text(c) for c in value]))
 
     def deconstruct(self):

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -422,6 +422,15 @@ class TestCountryMultiple(TestCase):
         self.assertEqual(obj.countries[0], "AU")
         self.assertEqual(obj.countries[1], "NZ")
 
+    def test_multiple_with_duplicates(self):
+        obj = MultiCountry(countries="AU,NZ,AU")
+        for country in obj.countries:
+            self.assertTrue(isinstance(country, fields.Country))
+        self.assertEqual(obj.countries, ["AU", "NZ"])
+
+        obj = MultiCountry(countries="")
+        self.assertEqual(obj.countries, [])
+
     def test_set_text(self):
         obj = MultiCountry()
         obj.countries = "NZ,AU"


### PR DESCRIPTION
always strip duplicate countries when saving a CountryField which has multiple=True (resolves #387)