### PR TITLE
Declare USE_TZ in test settings

### DIFF
--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -35,3 +35,5 @@ TEMPLATES = [
         },
     }
 ]
+
+USE_TZ = True


### PR DESCRIPTION
Fix this warning seen when running the tests on Django 4.0+:

```
$ tox -e py310-django40
...
===== warnings summary =====
.tox/py310-django40/lib/python3.10/site-packages/django/conf/__init__.py:206
  /.../site-packages/django/conf/__init__.py:206: RemovedInDjango50Warning: The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.
...
===== 177 passed, 2 warnings in 1.33s =====
_____ summary _____
  py310-django40: commands succeeded
  congratulations :)
```

As per this release note: https://docs.djangoproject.com/en/4.0/releases/4.0/#time-zone-support