### PR TITLE
Django 4.1 support

### DIFF
--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -35,5 +35,3 @@ TEMPLATES = [
         },
     }
 ]
-
-USE_TZ = True

--- a/django_countries/tests/settings.py
+++ b/django_countries/tests/settings.py
@@ -35,3 +35,5 @@ TEMPLATES = [
         },
     }
 ]
+
+USE_TZ = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ classifiers =
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
     Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
+    Framework :: Django :: 4.1
 
 [options]
 zip_safe = False

--- a/tox.ini
+++ b/tox.ini
@@ -34,16 +34,20 @@ deps =
     coverage
     drf310: djangorestframework==3.10.*
     drf311: djangorestframework==3.11.*
-    drf312,latest: djangorestframework==3.12.*
+    drf312: djangorestframework==3.12.*
+    drf313,latest: djangorestframework==3.13.*
     pyuca: pyuca
     django111: Django==1.11.*
     django22: Django==2.2.*
     django30: Django==3.0.*
     django31: Django==3.1.*
     django32: Django==3.2.*
-    django40,latest: Django==4.0.*
-    django40,latest: graphene-django==3.0.0b7
-    django40,latest: pytz
+    django40: Django==4.0.*
+    django40: graphene-django==3.0.0b7
+    django40: pytz
+    django41,latest: Django==4.1.*
+    django41,latest: graphene-django==3.0.0b7
+    django41,latest: pytz
 depends = coverage_setup
 commands = coverage run -m pytest
 


### PR DESCRIPTION
I think the `tox.ini` full list of environments is quite out of date, and so isn't even running Django 3.2+ tests on CI? But I wasn't confident there so I left it for you to investigate.

I ran with 4.1 locally and saw no new warnings, just the one from Django 4.0 fixed in #397 .