### PR TITLE
Add project URLs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,9 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+project_urls =
+    Change Log = https://github.com/SmileyChris/django-countries/blob/master/CHANGES.rst
+    Source Code = https://github.com/SmileyChris/django-countries
 
 [options]
 zip_safe = False


### PR DESCRIPTION
In particular, this will make it handy to jump from the PyPI project page to the change log file on GitHub.