### PR TITLE
Test on Django 4.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0
     Framework :: Django :: 4.1
+    Framework :: Django :: 4.2
 project_urls =
     Change Log = https://github.com/SmileyChris/django-countries/blob/main/CHANGES.rst
     Source Code = https://github.com/SmileyChris/django-countries

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     pyuca,legacy: pyuca
     legacy: Django==3.2.*
     previous: Django==4.0.*
-    latest: Django==4.1.*
+    latest: Django==4.2.*
     latest: graphene-django==3.0.*
 depends = coverage_setup
 commands = coverage run -m pytest


### PR DESCRIPTION
Update the test matrix to test with Django 4.2, the new LTS release. No changes were needed in the package for compatibility.

I wasn't quite sure whether we'd also move the "previous" and "legacy" pins. I would recommend supporting Django 3.2 through 4.2 for the time being, since 3.2 is still supported upstream until April 2024: https://www.djangoproject.com/download/#supported-versions