### PR TITLE
Fix importlib.metadata deprecation warning

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -15,20 +15,12 @@ from django.utils.html import escape as escape_html
 from django_countries import Countries, countries, filters, ioc_data, widgets
 from django_countries.conf import settings
 
-_entry_points: Iterable[Any]
-if sys.version_info >= (3, 8):
-    import importlib.metadata
-
-    if sys.version_info >= (3, 10):
-        _entry_points = importlib.metadata.entry_points(group="django_countries.Country")
-    else:
-        _entry_points = importlib.metadata.entry_points().get(
-            "django_countries.Country", []
-        )
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
 else:
-    import pkg_resources
+    from importlib_metadata import entry_points
 
-    _entry_points = pkg_resources.iter_entry_points("django_countries.Country")
+_entry_points = entry_points(group="django_countries.Country")
 
 EXTENSIONS = {ep.name: ep.load() for ep in _entry_points}  # type: ignore
 

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from typing import Any, Iterable, Optional, Tuple, Type, Union, cast
 from urllib import parse as urlparse
 
@@ -15,13 +16,16 @@ from django_countries import Countries, countries, filters, ioc_data, widgets
 from django_countries.conf import settings
 
 _entry_points: Iterable[Any]
-try:
+if sys.version_info >= (3, 8):
     import importlib.metadata
 
-    _entry_points = importlib.metadata.entry_points().get(
-        "django_countries.Country", []
-    )
-except ImportError:  # Python <3.8
+    if sys.version_info >= (3, 10):
+        _entry_points = importlib.metadata.entry_points(group="django_countries.Country")
+    else:
+        _entry_points = importlib.metadata.entry_points().get(
+            "django_countries.Country", []
+        )
+else:
     import pkg_resources
 
     _entry_points = pkg_resources.iter_entry_points("django_countries.Country")

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ packages = find:
 install_requires = 
     asgiref
     typing_extensions
+    importlib-metadata >= 3.6.0 ; python_version < "3.10"
 
 [options.extras_require]
 maintainer =

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     latest: Django==4.1.*
     latest: graphene-django==3.0.*
 depends = coverage_setup
-commands = coverage run -m pytest
+commands = coverage run -m pytest -Wall
 
 [testenv:readme]
 skip_install = True


### PR DESCRIPTION
Warning:

```
  django_countries/fields.py:21
    /home/runner/work/django-countries/django-countries/django_countries/fields.py:21: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
      _entry_points = importlib.metadata.entry_points().get(
```

Fix #439 

## Note

I've used `sys.version_info` and changed the pre-existing check for version <3.8 to use the same approach. This way, [pyupgrade](https://github.com/asottile/pyupgrade#python2-and-old-python3x-blocks) should fix it automatically when the project drop the older Python versions.