### PR TITLE
Prefer field_path for admin filter to follow relations

### DIFF
--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -12,20 +12,20 @@ class CountryFilter(admin.FieldListFilter):
     title = _("Country")  # type: ignore
 
     def expected_parameters(self):
-        return [self.field.name]
+        return [self.field_path]
 
     def choices(self, changelist):
-        value = self.used_parameters.get(self.field.name)
+        value = self.used_parameters.get(self.field_path)
         yield {
             "selected": value is None,
-            "query_string": changelist.get_query_string({}, [self.field.name]),
+            "query_string": changelist.get_query_string({}, [self.field_path]),
             "display": _("All"),
         }
         for lookup, title in self.lookup_choices(changelist):
             yield {
                 "selected": value == force_str(lookup),
                 "query_string": changelist.get_query_string(
-                    {self.field.name: lookup}, []
+                    {self.field_path: lookup}, []
                 ),
                 "display": title,
             }
@@ -34,8 +34,8 @@ class CountryFilter(admin.FieldListFilter):
         qs = changelist.model._default_manager.all()
         codes = set(
             qs.distinct()
-            .order_by(self.field.name)
-            .values_list(self.field.name, flat=True)
+            .order_by(self.field_path)
+            .values_list(self.field_path, flat=True)
         )
         for k, v in self.field.get_choices(include_blank=False):
             if k in codes:


### PR DESCRIPTION
When filtering on a `CountryField` from a relation, the admin will break with a `FieldError: 
Cannot resolve keyword 'country' into field. Choices are: ...`

Full example code:

```python
# models.py
class Contact(models.Model):
    country = CountryField(
        verbose_name=_("Country"),
        blank=True,
        null=True,
    )


class Payment(models.Model):
    contact = models.ForeignKey(
        "myapp.Contact", verbose_name=_("Contact"), on_delete=models.RESTRICT
    )
```

```python
# admin.py
class PaymentAdmin(ModelAdmin):
    model = Payment
    list_filter = [
        ("contact__country", CountryFilter),
    ]
```