### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.11"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.8", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ release, and any new translations added.
 
 - Drop Python 3.7 support.
 
+- Add Python 3.12 support.
+
 
 7.5.1 (1 February 2023)
 =======================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ release, and any new translations added.
 - Replace deprecated ``pkg_resources.iter_entry_points`` with
   ``importlib_metadata``.
 
+- Drop Python 3.7 support.
+
 
 7.5.1 (1 February 2023)
 =======================

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import re
 from typing import Any, Iterable, Optional, Tuple, Type, Union, cast
 from urllib import parse as urlparse
@@ -15,16 +16,9 @@ from django_countries import Countries, countries, filters, ioc_data, widgets
 from django_countries.conf import settings
 
 _entry_points: Iterable[Any]
-try:
-    import importlib.metadata
 
-    _entry_points = importlib.metadata.entry_points().get(
-        "django_countries.Country", []
-    )
-except ImportError:  # Python <3.8
-    import pkg_resources
+_entry_points = importlib.metadata.entry_points().get("django_countries.Country", [])
 
-    _entry_points = pkg_resources.iter_entry_points("django_countries.Country")
 
 EXTENSIONS = {ep.name: ep.load() for ep in _entry_points}  # type: ignore
 

--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import re
+import sys
 from typing import Any, Iterable, Optional, Tuple, Type, Union, cast
 from urllib import parse as urlparse
 
@@ -17,7 +18,11 @@ from django_countries.conf import settings
 
 _entry_points: Iterable[Any]
 
-_entry_points = importlib.metadata.entry_points().get("django_countries.Country", [])
+_entry_points = importlib.metadata.entry_points()
+if sys.version_info >= (3, 10):
+    _entry_points = _entry_points.select(group="django_countries.Country")
+else:
+    _entry_points = _entry_points.get("django_countries.Country", [])
 
 
 EXTENSIONS = {ep.name: ep.load() for ep in _entry_points}  # type: ignore

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Framework :: Django
     Framework :: Django :: 3.2
     Framework :: Django :: 4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ distribute = False
 envlist =
     coverage_setup
     # Latest
-    py311-latest{-pyuca,-noi18n}
+    py312-latest{-pyuca,-noi18n}
     # Historical Python, Django and DRF versions
-    py310-previous
+    py311-previous
     # Legacy
-    py37-legacy
+    py38-legacy
     # Package checks
     readme
     bandit
@@ -18,9 +18,10 @@ ignore_basepython_conflict = True
 
 [gh-actions]
 python =
-    3.7: py37
+    3.8: py38
     3.10: py310
-    3.11: py311, readme, bandit, mypy
+    3.11: py311
+    3.12: py312, readme, bandit, mypy
 
 [testenv]
 basepython = python3
@@ -50,7 +51,7 @@ commands =
     rst2html.py --report=info --halt=warning README.rst /dev/null
     rst2html.py --report=info --halt=warning CHANGES.rst /dev/null
 
-[py311-latest-noi18n]
+[py312-latest-noi18n]
 setenv = 
     DJANGO_SETTINGS_MODULE = django_countries.tests.settings_noi18n
 

--- a/tox.ini
+++ b/tox.ini
@@ -74,11 +74,11 @@ commands = coverage erase
 skip_install = True
 parallel_show_output = True
 depends =
-    py310-latest{-pyuca}
+    py312-latest{-pyuca}
     noi18n
-    py36-django32-drf312
+    py38-django32-drf312
     py39-django{32,40}-drf313
-    py36-legacy
+    py38-legacy
 commands =
   coverage combine
   coverage html


### PR DESCRIPTION
I've removed references to Python 3.6 and 3.7 (because of EOL) and increased the minimal Python version to 3.8.
The `get` method in `importlib.metadata.entry_points()` was removed in Python 3.12, so I used the `select` method instead. The `select` method was added in Python 3.10, so, to make mypy happy, I used the recommended:
```python
if sys.version_info >= (3, 10):
```

