### PR TITLE
Improve CountryFilter to play nice with multiple=True

### DIFF
--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -12,10 +12,16 @@ class CountryFilter(admin.FieldListFilter):
     title = _("Country")  # type: ignore
 
     def expected_parameters(self):
+        if self.field.multiple:
+            return [f"{self.field.name}__contains"]
         return [self.field.name]
 
     def choices(self, changelist):
-        value = self.used_parameters.get(self.field.name)
+        field_name = self.field.name
+        if self.field.multiple:
+            field_name = f"{field_name}__contains"
+
+        value = self.used_parameters.get(field_name)
         yield {
             "selected": value is None,
             "query_string": changelist.get_query_string({}, [self.field.name]),
@@ -24,18 +30,18 @@ class CountryFilter(admin.FieldListFilter):
         for lookup, title in self.lookup_choices(changelist):
             yield {
                 "selected": value == force_str(lookup),
-                "query_string": changelist.get_query_string(
-                    {self.field.name: lookup}, []
-                ),
+                "query_string": changelist.get_query_string({field_name: lookup}, []),
                 "display": title,
             }
 
     def lookup_choices(self, changelist):
         qs = changelist.model._default_manager.all()
         codes = set(
-            qs.distinct()
-            .order_by(self.field.name)
-            .values_list(self.field.name, flat=True)
+            ",".join(
+                qs.distinct()
+                .order_by(self.field.name)
+                .values_list(self.field.name, flat=True)
+            ).split(",")
         )
         for k, v in self.field.get_choices(include_blank=False):
             if k in codes:


### PR DESCRIPTION
The current implementation of the admin `CountryFilter` doesn't works well when `is_multiple=True`.
It filters when there is only one value (strict equality) instead of using `__contains`.

(This version handles that but not the possibility to search with multiple countries)