### PR TITLE
Include "Svalbard" in Dutch translation of "Svalbard and Jan Mayen"

### DIFF
--- a/django_countries/locale/nl/LC_MESSAGES/django.po
+++ b/django_countries/locale/nl/LC_MESSAGES/django.po
@@ -957,7 +957,7 @@ msgstr "Suriname"
 
 #: data.py:245
 msgid "Svalbard and Jan Mayen"
-msgstr "Jan Mayen"
+msgstr "Spitsbergen en Jan Mayen"
 
 #: data.py:246
 msgid "Sweden"


### PR DESCRIPTION
In the Dutch translation of "Svalbard and Jan Mayen", only "Jan Mayen" was translated, not ["Svalbard"](https://nl.wikipedia.org/wiki/Spitsbergen)