### PR TITLE
Update widgets.py to support Django 5.0

### DIFF
--- a/django_countries/widgets.py
+++ b/django_countries/widgets.py
@@ -30,12 +30,13 @@ class LazyChoicesMixin:
         return self._choices
 
     def set_choices(self, value: ChoiceList):
-        self._set_choices(value)
+        # self._set_choices(value)
+        self._choices = value
 
     choices = property(get_choices, set_choices)
 
-    def _set_choices(self, value: ChoiceList):
-        self._choices = value
+    # def _set_choices(self, value: ChoiceList):
+    #     self._choices = value
 
 
 class LazySelectMixin(LazyChoicesMixin):


### PR DESCRIPTION
commented out `_set_choices` and directly assigned the value in `set_choices`.

This fixes the `AttributeError: 'BlankChoiceIterator' object has no attribute '__len__'`