### PR TITLE
Fix TypeError in CountryFilter.choices()

### DIFF
--- a/django_countries/filters.py
+++ b/django_countries/filters.py
@@ -24,7 +24,7 @@ class CountryFilter(admin.FieldListFilter):
         }
         for lookup, title in self.lookup_choices(changelist):
             if django.VERSION >= (5, 0):
-                selected = force_str(lookup) in value
+                selected = value is not None and force_str(lookup) in value
             else:
                 selected = force_str(lookup) == value
             yield {


### PR DESCRIPTION
When no country is selected, self.used_parameters.get(self.field.name) will return None. This raises a TypeError when CountryFilter.choices() tries to check whether a specific country choice is currently selected.

Avoid this by checking that the parameter is not empty similarly to how Django's built-in admin.filters.RelatedFieldListFilter checks for this.

Fixes: 04662d1e282d ("Support Django 5.0")