### PR TITLE
Fix bug in max_length calculation for CountryField with multiple=True

### DIFF
--- a/django_countries/fields.py
+++ b/django_countries/fields.py
@@ -298,7 +298,7 @@ class CountryField(CharField):
             # added to the available countries dictionary.
             if self.multiple:
                 kwargs["max_length"] = (
-                    len(self.countries)
+                    len(self.countries.countries)
                     - 1
                     + sum(len(code) for code in self.countries.countries)
                 )

--- a/django_countries/tests/test_fields.py
+++ b/django_countries/tests/test_fields.py
@@ -492,6 +492,25 @@ class TestCountryMultiple(TestCase):
         self.assertEqual(list(qs), [obj])
 
 
+class TestCountryFieldFirstRepeatMultiple(TestCase):
+    def setUp(self):
+        del countries.countries
+
+    def tearDown(self):
+        del countries.countries
+
+    @override_settings(COUNTRIES_FIRST=["NZ", "AU"], COUNTRIES_FIRST_REPEAT=True)
+    def test_max_length(self):
+        field = CountryField(multiple=True)
+
+        # verify there are two additional choices
+        self.assertEqual(len(list(field.get_choices())), len(data.COUNTRIES) + 2)
+
+        # but they should not change the field's max_length
+        expected_max_length = len(data.COUNTRIES) * 3 - 1
+        self.assertEqual(field.max_length, expected_max_length)
+
+
 class TestCountryObject(TestCase):
     def test_hash(self):
         country = fields.Country(code="XX", flag_url="")


### PR DESCRIPTION
Fixes #469.

I'm not sure if there is a better way to test this - the `override_settings` decorator does not affect the test models, so I just instantiated a `CountryField` directly. Also `del`ing the `countries.countries` in a test inside the `TestCountryMultiple` messes up other tests in the class, so I added a new one with `setUp` and `tearDown` to make sure the test would fail without the fix.