### PR TITLE
German translation: Update country names

### DIFF
--- a/django_countries/locale/de/LC_MESSAGES/django.po
+++ b/django_countries/locale/de/LC_MESSAGES/django.po
@@ -186,7 +186,7 @@ msgstr "Barbados"
 
 #: data.py:52
 msgid "Belarus"
-msgstr "Weißrussland"
+msgstr "Belarus"
 
 #: data.py:53
 msgid "Belgium"
@@ -414,7 +414,7 @@ msgstr "Frankreich"
 
 #: data.py:109
 msgid "French Guiana"
-msgstr "Französisch Guinea"
+msgstr "Französisch-Guayana"
 
 #: data.py:110
 msgid "French Polynesia"


### PR DESCRIPTION
"Belarus" is today named "Belarus" in German. The name "Weißrussland" is no longer officially used since 2021, including by German authorities. Source: https://de.wikipedia.org/wiki/Belarus#%E2%80%9EWei%C3%9Frussland%E2%80%9C_und_%E2%80%9EBelarus%E2%80%9C

"Französisch-Guinea" has always been a wrong translation of "French Guinea". "Französisch-Guinea" refers to the historic French colony Guinée française which is today the independent state of Guinea. Today's French Guinea, which is a department of the French republic, is called "Französisch-Guayana" in German. Source: https://de.wikipedia.org/wiki/Franz%C3%B6sisch-Guayana