### PR TITLE
Add locale-sorted countries helper

### DIFF
--- a/changes/+20260215-locale-sorted-helper.feature.md
+++ b/changes/+20260215-locale-sorted-helper.feature.md
@@ -1,0 +1,1 @@
+Add an opt-in `Countries.sorted(locale=...)` helper to return country choices sorted by translated display names.

--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import builtins as _builtins
 import itertools
 import re
 from contextlib import contextmanager
@@ -6,6 +7,7 @@ from gettext import NullTranslations
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -657,18 +659,40 @@ class Countries(CountriesBase):
         self._iter_cache[cache_key] = results
         yield from results
 
-    def sorted(self, *, locale: Optional[str] = None) -> List[CountryTuple]:
+    def sorted(
+        self,
+        *,
+        locale: Optional[str] = None,
+        key: Optional[Callable] = None,
+        reverse: bool = False,
+    ) -> List[CountryTuple]:
         """
         Return a list of countries sorted by translated name for a locale.
 
         This respects the same ordering rules as iteration (first countries,
         overrides, and context options). When no locale is provided, the
         current active language is used.
+
+        When ``key`` is provided, it is forwarded to the built-in
+        :func:`sorted` as a secondary sort applied on top of the
+        locale-ordered list. Note that this re-sorts the entire list and
+        ignores the :setting:`COUNTRIES_FIRST` grouping — use this when you
+        want a uniform custom ordering.
+
+        When only ``reverse`` is provided (without ``key``), the
+        locale-ordered list is simply reversed in place, preserving
+        :setting:`COUNTRIES_FIRST` as a trailing group.
         """
         if locale:
             with override(locale):
-                return list(self)
-        return list(self)
+                result = list(self)
+        else:
+            result = list(self)
+        if key is not None:
+            return _builtins.sorted(result, key=key, reverse=reverse)
+        if reverse:
+            result.reverse()
+        return result
 
     def alpha2(self, code: "CountryCode") -> str:
         """

--- a/django_countries/__init__.py
+++ b/django_countries/__init__.py
@@ -657,6 +657,19 @@ class Countries(CountriesBase):
         self._iter_cache[cache_key] = results
         yield from results
 
+    def sorted(self, *, locale: Optional[str] = None) -> List[CountryTuple]:
+        """
+        Return a list of countries sorted by translated name for a locale.
+
+        This respects the same ordering rules as iteration (first countries,
+        overrides, and context options). When no locale is provided, the
+        current active language is used.
+        """
+        if locale:
+            with override(locale):
+                return list(self)
+        return list(self)
+
     def alpha2(self, code: "CountryCode") -> str:
         """
         Return the normalized country code when passed any type of ISO 3166-1

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -102,6 +102,13 @@ class TestCountriesObject(BaseTest):
         finally:
             translation.activate(lang)
 
+    @pytest.mark.skipif(not settings.USE_I18N, reason="No i18n")
+    def test_sorted_locale_translates(self):
+        lang = translation.get_language()
+        result = countries.sorted(locale="de")
+        self.assertEqual(dict(result)["BO"], "Bolivien")
+        self.assertEqual(translation.get_language(), lang)
+
     def test_alpha2(self):
         self.assertEqual(countries.alpha2("NZ"), "NZ")
         self.assertEqual(countries.alpha2("nZ"), "NZ")

--- a/django_countries/tests/test_countries.py
+++ b/django_countries/tests/test_countries.py
@@ -109,6 +109,16 @@ class TestCountriesObject(BaseTest):
         self.assertEqual(dict(result)["BO"], "Bolivien")
         self.assertEqual(translation.get_language(), lang)
 
+    def test_sorted_key(self):
+        result = countries.sorted(key=lambda item: item[0])
+        codes = [c[0] for c in result]
+        self.assertEqual(codes, sorted(codes))
+
+    def test_sorted_reverse(self):
+        result = countries.sorted(reverse=True)
+        normal = countries.sorted()
+        self.assertEqual(result, list(reversed(normal)))
+
     def test_alpha2(self):
         self.assertEqual(countries.alpha2("NZ"), "NZ")
         self.assertEqual(countries.alpha2("nZ"), "NZ")

--- a/docs/usage/field.md
+++ b/docs/usage/field.md
@@ -286,6 +286,19 @@ Albania (AL)
 "Bolivien"
 ```
 
+The ``key`` and ``reverse`` parameters are forwarded to the built-in
+:func:`sorted` as a secondary sort on top of the locale-ordered list.
+
+When ``key`` is provided, the list is re-sorted uniformly (ignoring
+:setting:`COUNTRIES_FIRST` grouping). When only ``reverse`` is given
+without ``key``, the list is reversed in place, preserving the first
+countries at the end:
+
+```python
+>>> by_code = countries.sorted(key=lambda item: item[0])
+>>> reversed_list = countries.sorted(reverse=True)
+```
+
 ## See Also
 
 - [Multiple Countries](../advanced/multiple.md) - Select multiple countries in a single field

--- a/docs/usage/field.md
+++ b/docs/usage/field.md
@@ -274,6 +274,18 @@ Afghanistan (AF)
 Albania (AL)
 ```
 
+!!! info "New in development version"
+
+    Use `countries.sorted(locale=...)` to return a list sorted by translated
+    display names for a specific locale:
+
+```python
+>>> from django_countries import countries
+>>> de_list = countries.sorted(locale="de")
+>>> dict(de_list)["BO"]
+"Bolivien"
+```
+
 ## See Also
 
 - [Multiple Countries](../advanced/multiple.md) - Select multiple countries in a single field


### PR DESCRIPTION
This PR adds a new helper `Countries.sorted(locale=...)` that did not exist before. Previously, locale-specific ordering required changing the active language and iterating **`countries`**. The new helper provides an explicit, opt‑in way to get a list sorted by translated display names without touching global state.

## Why this improves UX

- Users see country lists sorted in their language, which makes dropdowns faster to scan and feel more natural.
- Avoids confusing order for non‑English locales where Unicode code‑point sorting looks wrong.
- Keeps existing behavior unchanged unless the helper is used (no breaking changes).

## What’s included

- New helper in `__init__.py`:655-672
- Test coverage in `test_countries.py`
- Docs and changelog updates

## How to test
Run:

- `uv run pytest django_countries/tests/test_countries.py::TestCountriesObject::test_sorted_locale_translates`
- Optional: 

1. `DJANGO_SETTINGS_MODULE=django_countries.tests.settings uv run python -m django shell` 
2. `from django_countries import countries; countries.sorted(locale="de")[:3]`

<img width="915" height="201" alt="Screenshot 2026-02-15 at 03 39 10" src="https://github.com/user-attachments/assets/af07d2f6-9000-481a-8919-5780613dabd1" />
