### PR TITLE
Actually test against Django 5.2

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -84,7 +84,7 @@ just test previous 3.9     # Django 4.2 with Python 3.9
 Test environments:
 - **legacy**: Python 3.8 + Django 3.2 + DRF 3.11
 - **previous**: Python 3.10 + Django 4.2 + DRF 3.14
-- **latest**: Python 3.13 + Django 5.2 + DRF 3.15
+- **latest**: Python 3.13 + Django 5.2 + DRF 3.16
 - **latest-pyuca**: Latest + pyuca (Unicode collation)
 - **latest-noi18n**: Latest + i18n disabled
 

--- a/justfile
+++ b/justfile
@@ -81,16 +81,16 @@ _test-env ENV PYTHON:
             ;; \
         latest) \
             uv run --python {{ PYTHON }} \
-                   --with "Django==5.1.*" \
-                   --with "djangorestframework==3.15.*" \
+                   --with "Django==5.2.*" \
+                   --with "djangorestframework==3.16.*" \
                    --with "graphene-django==3.0.*" \
                    --group test \
                    coverage run -m pytest \
             ;; \
         latest-pyuca) \
             uv run --python {{ PYTHON }} \
-                   --with "Django==5.1.*" \
-                   --with "djangorestframework==3.15.*" \
+                   --with "Django==5.2.*" \
+                   --with "djangorestframework==3.16.*" \
                    --with "graphene-django==3.0.*" \
                    --with "pyuca" \
                    --group test \
@@ -99,8 +99,8 @@ _test-env ENV PYTHON:
         latest-noi18n) \
             DJANGO_SETTINGS_MODULE=django_countries.tests.settings_noi18n \
             uv run --python {{ PYTHON }} \
-                   --with "Django==5.1.*" \
-                   --with "djangorestframework==3.15.*" \
+                   --with "Django==5.2.*" \
+                   --with "djangorestframework==3.16.*" \
                    --with "graphene-django==3.0.*" \
                    --group test \
                    coverage run -m pytest \


### PR DESCRIPTION
While the documentation indicates tests are running against Django 5.2, it seems like the `justfile` had Django 5.1 pinned. This resolves that and pins Django 5.2.x instead. I've also bumped the DRF version for the "latest" tests to one that is officially compatible with Django 5.2.